### PR TITLE
Fix nonexisting apis

### DIFF
--- a/internal/dashboard_client/api.go
+++ b/internal/dashboard_client/api.go
@@ -157,7 +157,7 @@ func (a Api) Delete(id string) error {
 	}
 
 	if res.StatusCode == http.StatusNotFound {
-		// Tyk returns internal server error if api is already deleted
+		// Tyk returns 404 if api is already deleted
 		return nil
 	}
 


### PR DESCRIPTION
The  status code on. Tyk returning error for non-existing APIs is `404` not` 500`

```
curl localhost:3000/api/apis/5f8c279dd3626e92de572511 -X DELETE -H 'Authorization: ebd9eee392d24c24578850b0f00da71f' -i
HTTP/1.1 404 Not Found
Access-Control-Allow-Credentials: true
Cache-Control: no-store, no-cache, private
Content-Type: application/json
Strict-Transport-Security: max-age=63072000; includeSubDomains
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Date: Mon, 19 Oct 2020 18:46:11 GMT
Content-Length: 72

{"Status":"Error","Message":"Could not retrieve API detail","Meta":null}
```