### PR TITLE
docs: api_definitions document active field

### DIFF
--- a/docs/api_definitions.md
+++ b/docs/api_definitions.md
@@ -74,6 +74,14 @@ An API Definition describes the configuration of an API. It instructs Tyk Gatewa
 | Tag Headers | ❌ | Not Implemented |
 | [Webhooks](./webhooks.md) | ❌ | [WIP #62](https://github.com/TykTechnologies/tyk-operator/issues/62) |
 
+# Pro features
+
+These are features which are only available to tyk PRO users
+
+| Feature | Supported | Comment |
+|---------|-----------|---------|
+| [Active API](./api_definitions/fields.md#active) |⚠️ | Untested|
+
 ## APIDefinition - Endpoint Middleware
 
 | Endpoint Middleware  | Supported | Comments |

--- a/docs/api_definitions.md
+++ b/docs/api_definitions.md
@@ -80,7 +80,7 @@ These are features which are only available to tyk PRO users
 
 | Feature | Supported | Comment |
 |---------|-----------|---------|
-| [Active API](./api_definitions/fields.md#active) |⚠️ | Untested|
+| [Active API](./api_definitions/fields.md#active) |✅ | Untested|
 
 ## APIDefinition - Endpoint Middleware
 

--- a/docs/api_definitions/fields.md
+++ b/docs/api_definitions/fields.md
@@ -1,0 +1,31 @@
+This contains some comments /explanations about fields that are in the CRD on what
+they are used for.
+
+If you need to link anything into tables that needs additional explanation and is 
+a field in the APIDefinition resource it goes here.
+
+
+# active
+
+This determines whether the api definition will be loaded on the tyk gateway or not.
+
+Example
+
+```yaml
+apiVersion: tyk.tyk.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: httpbin
+spec:
+  name: httpbin
+  use_keyless: true
+  protocol: http
+  active: false
+  proxy:
+    target_url: http://httpbin.org
+    listen_path: /httpbin
+    strip_listen_path: true
+```
+
+A `httpbin` api will be created and stored in tyk pro but it will not be loaded on the gateways , calling the service will result in `404`
+


### PR DESCRIPTION
This adds documentation for active field of the api definition. It is a
tyk pro feature that is not available on community edition.

We are adding a new table to track features that are only available on
tyk pro

Closes #151