### PR TITLE
Feat/helm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "helm"]
-	path = helm
-	url = git@github.com:drpebcak/tyk-operator-helm.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "helm"]
+	path = helm
+	url = git@github.com:drpebcak/tyk-operator-helm.git

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ helm: kustomize
 	sed -i '' 's#tyk-operator-conf#{{ \.Values\.confSecretName }}#' helm/templates/all.yaml
 	sed -i '' 's#tykio/tyk-operator:latest#{{ \.Values\.image\.repository }}:{{ \.Values\.image\.tag }}#' helm/templates/all.yaml
 	sed -i '' 's#imagePullPolicy: IfNotPresent#imagePullPolicy: {{ .Values.image.pullPolicy }}#' helm/templates/all.yaml
-	#sed -i '' 's#name: default#name: {{ include "tyk-operator-helm\.serviceAccountName" . }}#' helm/templates/all.yaml
+	sed -i '' 's#name: default#name: {{ include "tyk-operator-helm\.serviceAccountName" \. }}#' helm/templates/all.yaml
+	sed -i '' 's#serviceAccountName: default#serviceAccountName: {{ include "tyk-operator-helm\.serviceAccountName" \. }}#' helm/templates/all.yaml
 
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,14 @@ deploy: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
-# Generate manifests e.g. CRD, RBAC etc.
+helm: kustomize
+	$(KUSTOMIZE) build config/helm > ./helm/templates/all.yaml
+	sed -i '' 's#replicas: 1#replicas: {{ \.Values.replicaCount }}#' helm/templates/all.yaml
+	sed -i '' 's#tyk-operator-conf#{{ \.Values\.confSecretName }}#' helm/templates/all.yaml
+	sed -i '' 's#tykio/tyk-operator:latest#{{ \.Values\.image\.repository }}:{{ \.Values\.image\.tag }}#' helm/templates/all.yaml
+	sed -i '' 's#imagePullPolicy: IfNotPresent#imagePullPolicy: {{ .Values.image.pullPolicy }}#' helm/templates/all.yaml
+	#sed -i '' 's#name: default#name: {{ include "tyk-operator-helm\.serviceAccountName" . }}#' helm/templates/all.yaml
+
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
@@ -108,7 +115,7 @@ ifeq (, $(shell which kustomize))
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
+	go get sigs.k8s.io/kustomize/kustomize/v3@v3.8.6 ;\
 	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
 	}
 KUSTOMIZE=$(GOBIN)/kustomize

--- a/ci/deploy_tyk_ce.sh
+++ b/ci/deploy_tyk_ce.sh
@@ -10,7 +10,7 @@ kubectl create namespace ${NAMESPACE}
 
 echo "deploying gRPC plugin server"
 kubectl apply -f "${PRODIR}/../grpc-plugin" -n ${NAMESPACE}
-kubectl wait deployment/grpc-plugin -n ${NAMESPACE} --for condition=available --timeout=10s
+kubectl wait deployment/grpc-plugin -n ${NAMESPACE} --for condition=available --timeout=30s
 
 echo "deploying databases"
 kubectl apply -f "${PRODIR}/redis" -n ${NAMESPACE}

--- a/ci/deploy_tyk_pro.sh
+++ b/ci/deploy_tyk_pro.sh
@@ -11,7 +11,7 @@ kubectl create namespace ${NAMESPACE}
 
 echo "deploying gRPC plugin server"
 kubectl apply -f "${PRODIR}/../grpc-plugin" -n ${NAMESPACE}
-kubectl wait deployment/grpc-plugin -n ${NAMESPACE} --for condition=available --timeout=10s
+kubectl wait deployment/grpc-plugin -n ${NAMESPACE} --for condition=available --timeout=30s
 
 echo "deploying databases"
 kubectl apply -f "${PRODIR}/mongo/mongo.yaml" -n ${NAMESPACE}

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -1,47 +1,30 @@
 # Adds namespace to all resources.
-namespace: tyk-operator-system
+namespace: "{{ .Release.Namespace }}"
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: tyk-operator-
+namePrefix: '{{ include "tyk-operator-helm.fullname" . }}-'
 
 # Labels to add to all resources and selectors.
 #commonLabels:
 #  someName: someValue
 
 resources:
-- ../crd
+#- ../crd
 - ../rbac
-- ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
+- ../manager-helm
 - ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
-  # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, please comment the following line.
-#- manager_auth_proxy_patch.yaml
-
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
 - manager_webhook_patch.yaml
-
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
-# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
-# 'CERTMANAGER' needs to be enabled to use ca injection
 - webhookcainjection_patch.yaml
 
-# the following config is for teaching kustomize how to do var substitution
 vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
   objref:
     kind: Certificate

--- a/config/helm/manager_webhook_patch.yaml
+++ b/config/helm/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/helm/webhookcainjection_patch.yaml
+++ b/config/helm/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/manager-helm/kustomization.yaml
+++ b/config/manager-helm/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: tykio/tyk-operator
+  newTag: latest

--- a/config/manager-helm/manager.yaml
+++ b/config/manager-helm/manager.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      serviceAccountName: default
       containers:
       - command:
         - /manager

--- a/config/manager-helm/manager.yaml
+++ b/config/manager-helm/manager.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - command:
+        - /manager
+        args:
+        - --enable-leader-election
+        image: controller:latest
+        name: manager
+        imagePullPolicy: IfNotPresent
+        envFrom:
+          - secretRef:
+              name: tyk-operator-conf
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -43,6 +43,16 @@ kubectl create secret -n tyk-operator-system generic tyk-operator-conf \
   --from-literal "TYK_MODE=${TYK_MODE}" \
   --from-literal "TYK_URL=${TYK_URL}"
 ```
+Examples of these values:
+
+|         | TYK_ORG     | TYK_AUTH       | TYK_URL            | TYK_MODE |
+|---------|-------------|----------------|--------------------|----------|
+| Tyk Pro | User Org ID, ie "5e9d9544a1dcd60001d0ed20" | User API Key, ie "2d095c2155774fe36d77e5cbe3ac963b"   | Dashboard Base URL, ie "http://localhost:3000" | "pro"    |
+| Tyk Hybrid | User Org ID | User API Key   | "https://admin.cloud.tyk.io/" | "pro"    |
+| Tyk OSS |      "foo"       | Gateway secret | Gateway Base URL   | "oss"    |
+
+
+And after you run the command, the values get automatically Base64 encoded:
 
 ```
 k get secret/tyk-operator-conf -n tyk-operator-system -o json | jq '.data'

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -1,6 +1,14 @@
 # tyk-operator installation
 
-## prerequisites
+- [Prerequisites](#prerequisites)
+- [Installing Tyk](#installing-tyk)
+- [Configuring Tyk Operator Secrets](#configuring-tyk-operator-secrets)
+- [Installing CRDs](#installing-crds)
+- [Installing cert-manager](#installing-cert-manager)
+- [Installing tyk-operator](#installing-tyk-operator)
+- [Uninstall](#uninstall)
+
+### prerequisites
 
 Before running the operator
 
@@ -14,22 +22,19 @@ Before running the operator
 We shall assume you already have a deployed and bootstrapped Tyk installation. If not, head over to 
 [tyk-helm-chart](https://github.com/TykTechnologies/tyk-helm-chart/), to install Tyk.
 
-{{box op="start" cssClass="boxed tipBox"}}
-**Tip!**
-
 The Tyk Installation does not need to be deployed inside K8s. You may already have a fully-functioning Tyk installation.
 
 Using Tyk Operator, you can manage APIs in any Tyk installation whether self-hosted, K8s or Tyk Cloud. As long as the 
 management URL is accessible by the operator.
-{{box op="end"}}
 
 ### Configuring tyk-operator secrets
 
-By default, the operator deploys to the `tyk-operator-system` namespace. This example sets the appropriate secrets 
-tyk-operator needs to connect to a Tyk Pro deployment.
+tyk-operator needs to connect to a Tyk Pro deployment. And it needs to know whether it is talking to a Community
+ Edition Gateway or Pro installation.
+
+`TYK_MODE` can be `oss` or `pro`.
 
 ```bash
-
 kubectl create namespace tyk-operator-system
 
 kubectl create secret -n tyk-operator-system generic tyk-operator-conf \
@@ -37,7 +42,6 @@ kubectl create secret -n tyk-operator-system generic tyk-operator-conf \
   --from-literal "TYK_ORG=${TYK_ORG}" \
   --from-literal "TYK_MODE=${TYK_MODE}" \
   --from-literal "TYK_URL=${TYK_URL}"
-
 ```
 
 ```
@@ -66,7 +70,7 @@ customresourcedefinition.apiextensions.k8s.io/webhooks.tyk.tyk.io configured
 
 ### Installing cert-manager
 
-Quick install
+If you don't have cert-manager installed: Quick install
 
 ```bash
 kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.3/cert-manager.yaml
@@ -100,32 +104,19 @@ replicaset.apps/cert-manager-webhook-6d4c5c44bb      1         1         0      
 
 ## Installing tyk-operator
 
-If you wish to change the namespace that tyk-operator is deployed from the default `tyk-operator-system`:
+Run the following to deploy tyk-operator. 
 
-```bash
-cd config/default/ && kustomize edit set namespace "yournamespace" && cd ../..
 ```
+$ helm install foo ./helm -n tyk-operator-system
 
-Run the following to deploy tyk-operator. This will also install the RBAC manifests from config/rbac. 
-
-```bash
-make deploy IMG=tykio/tyk-operator:latest
-```
-
-```bash
-k get all -n tyk-operator-system
-NAME                                                   READY   STATUS    RESTARTS   AGE
-pod/tyk-operator-controller-manager-6f554ffb59-244tj   2/2     Running   1          2m14s
-
-NAME                                                      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
-service/tyk-operator-controller-manager-metrics-service   ClusterIP   10.245.198.147   <none>        8443/TCP   2m22s
-service/tyk-operator-webhook-service                      ClusterIP   10.245.143.252   <none>        443/TCP    2m21s
-
-NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/tyk-operator-controller-manager   1/1     1            1           2m18s
-
-NAME                                                         DESIRED   CURRENT   READY   AGE
-replicaset.apps/tyk-operator-controller-manager-6f554ffb59   1         1         1       2m17s
+NAME: foo
+LAST DEPLOYED: Tue Nov 10 18:38:32 2020
+NAMESPACE: tyk-operator-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+You have deployed the tyk-operator! See https://github.com/TykTechnologies/tyk-operator for more information.
 ```
 
 ## Uninstall
@@ -134,5 +125,5 @@ Did we do something wrong? Create a [GH issue](https://github.com/TykTechnologie
 maybe we can try to improve your experience, or that of others. 
 
 ```
-make uninstall
+helm delete foo
 ```

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: to
+description: A Helm chart to install the tyk-operator
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
-name: to
+name: tyk-operator
 description: A Helm chart to install the tyk-operator
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.0 # version of the helm chart

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,1 @@
+You have deployed the tyk-operator! See https://github.com/TykTechnologies/tyk-operator for more information.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tyk-operator-helm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tyk-operator-helm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tyk-operator-helm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tyk-operator-helm.labels" -}}
+helm.sh/chart: {{ include "tyk-operator-helm.chart" . }}
+{{ include "tyk-operator-helm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tyk-operator-helm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tyk-operator-helm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tyk-operator-helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tyk-operator-helm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/all.yaml
+++ b/helm/templates/all.yaml
@@ -1,0 +1,285 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ include "tyk-operator-helm.fullname" . }}-leader-election-role'
+  namespace: '{{ .Release.Namespace }}'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: '{{ include "tyk-operator-helm.fullname" . }}-manager-role'
+rules:
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - apidefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - apidefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - organizations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - organizations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - securitypolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - securitypolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - webhooks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tyk.tyk.io
+  resources:
+  - webhooks/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ include "tyk-operator-helm.fullname" . }}-leader-election-rolebinding'
+  namespace: '{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "tyk-operator-helm.fullname" . }}-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{ include "tyk-operator-helm.fullname" . }}-manager-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "tyk-operator-helm.fullname" . }}-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: '{{ include "tyk-operator-helm.fullname" . }}-webhook-service'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: '{{ include "tyk-operator-helm.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        command:
+        - /manager
+        envFrom:
+        - secretRef:
+            name: {{ .Values.confSecretName }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: '{{ include "tyk-operator-helm.fullname" . }}-serving-cert'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  dnsNames:
+  - '{{ include "tyk-operator-helm.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
+  - '{{ include "tyk-operator-helm.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local'
+  issuerRef:
+    kind: Issuer
+    name: '{{ include "tyk-operator-helm.fullname" . }}-selfsigned-issuer'
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: '{{ include "tyk-operator-helm.fullname" . }}-selfsigned-issuer'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "tyk-operator-helm.fullname" . }}-serving-cert'
+  name: '{{ include "tyk-operator-helm.fullname" . }}-mutating-webhook-configuration'
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: '{{ include "tyk-operator-helm.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /mutate-tyk-tyk-io-v1alpha1-apidefinition
+  failurePolicy: Fail
+  name: mapidefinition.kb.io
+  rules:
+  - apiGroups:
+    - tyk.tyk.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - apidefinitions
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "tyk-operator-helm.fullname" . }}-serving-cert'
+  name: '{{ include "tyk-operator-helm.fullname" . }}-validating-webhook-configuration'
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: '{{ include "tyk-operator-helm.fullname" . }}-webhook-service'
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-tyk-tyk-io-v1alpha1-apidefinition
+  failurePolicy: Fail
+  name: vapidefinition.kb.io
+  rules:
+  - apiGroups:
+    - tyk.tyk.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - apidefinitions
+  sideEffects: None

--- a/helm/templates/all.yaml
+++ b/helm/templates/all.yaml
@@ -130,7 +130,7 @@ roleRef:
   name: '{{ include "tyk-operator-helm.fullname" . }}-leader-election-role'
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "tyk-operator-helm.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -143,7 +143,7 @@ roleRef:
   name: '{{ include "tyk-operator-helm.fullname" . }}-manager-role'
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: {{ include "tyk-operator-helm.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: v1
@@ -201,6 +201,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      serviceAccountName: {{ include "tyk-operator-helm.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tyk-operator-helm.serviceAccountName" . }}
+  labels:
+    {{- include "tyk-operator-helm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,49 @@
+replicaCount: 1
+confSecretName: tyk-operator-conf
+
+image:
+  repository: tykio/tyk-operator
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+rbacProxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: "v0.5.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "tyk-operator"
+
+annotations: {}
+podAnnotations: {}
+podSecurityContext: {}
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+clusterDnsDomain: cluster.local


### PR DESCRIPTION
Resolves: https://github.com/TykTechnologies/tyk-operator/issues/91

Please delete your local copy of kustomize, it contains a bugged version of `go-yaml` which splits long lines onto multi-lines.

To generate the helm chart template:

```
make helm
```

this will scaffold the chart into `./helm/templates/all.yaml`

then using `BSD sed`, we override specific parts of the operator deployment:

```
	sed -i '' 's#replicas: 1#replicas: {{ \.Values.replicaCount }}#' helm/templates/all.yaml
	sed -i '' 's#tyk-operator-conf#{{ \.Values\.confSecretName }}#' helm/templates/all.yaml
	sed -i '' 's#tykio/tyk-operator:latest#{{ \.Values\.image\.repository }}:{{ \.Values\.image\.tag }}#' helm/templates/all.yaml
	sed -i '' 's#imagePullPolicy: IfNotPresent#imagePullPolicy: {{ .Values.image.pullPolicy }}#' helm/templates/all.yaml
        ...
        ...
```

TODO: Template resources - e.g. set defaults. but make configurable from values.yaml

```
        resources:
          limits:
            cpu: 100m
            memory: 30Mi
          requests:
            cpu: 100m
            memory: 20Mi
```
