### PR TITLE
ability to restrict watched resources by namespace

### DIFF
--- a/ci/deploy_tyk_pro.sh
+++ b/ci/deploy_tyk_pro.sh
@@ -5,6 +5,7 @@ set -e
 NAMESPACE=tykpro-control-plane
 PRODIR=${PWD}/ci/tyk-pro
 ADMINSECRET="54321"
+TIMEOUT=60s
 
 echo "creating namespace ${NAMESPACE}"
 if OUTPUT=$(kubectl get namespaces 2> /dev/null | grep "${NAMESPACE}") ; then
@@ -16,32 +17,32 @@ fi
 
 echo "deploying gRPC plugin server"
 kubectl apply -f "${PRODIR}/../grpc-plugin" -n ${NAMESPACE}
-kubectl wait deployment/grpc-plugin -n ${NAMESPACE} --for condition=available --timeout=30s
+kubectl wait deployment/grpc-plugin -n ${NAMESPACE} --for condition=available --timeout=${TIMEOUT}
 
 echo "deploying databases"
 kubectl apply -f "${PRODIR}/mongo/mongo.yaml" -n ${NAMESPACE}
 kubectl apply -f "${PRODIR}/redis" -n ${NAMESPACE}
 
 echo "waiting for redis"
-kubectl wait deployment/redis -n ${NAMESPACE} --for condition=available --timeout=60s
+kubectl wait deployment/redis -n ${NAMESPACE} --for condition=available --timeout=${TIMEOUT}
 echo "waiting for mongo"
-kubectl wait deployment/mongo -n ${NAMESPACE} --for condition=available --timeout=60s
+kubectl wait deployment/mongo -n ${NAMESPACE} --for condition=available --timeout=${TIMEOUT}
 
 echo "creating configmaps"
-kubectl create configmap -n ${NAMESPACE} dash-conf --from-file "${PRODIR}/dashboard/confs/dash.json"
-kubectl create configmap -n ${NAMESPACE} tyk-conf --from-file "${PRODIR}/gateway/confs/tyk.json"
+kubectl create configmap -n ${NAMESPACE} dash-conf --dry-run=client --from-file "${PRODIR}/dashboard/confs/dash.json" -o yaml | kubectl apply -f -
+kubectl create configmap -n ${NAMESPACE} tyk-conf --dry-run=client --from-file "${PRODIR}/gateway/confs/tyk.json" -o yaml | kubectl apply -f -
 
 echo "setting dashboard secrets"
-kubectl create secret -n ${NAMESPACE} generic dashboard --from-literal "license=${TYK_DB_LICENSEKEY}" --from-literal "adminSecret=${ADMINSECRET}"
-kubectl get secret/dashboard -n tykpro-control-plane -o json | jq '.data.license'
+kubectl create secret -n ${NAMESPACE} generic dashboard --dry-run=client --from-literal "license=${TYK_DB_LICENSEKEY}" --from-literal "adminSecret=${ADMINSECRET}" -o yaml | kubectl apply -f -
+kubectl get secret/dashboard -n tykpro-control-plane -o jsonpath='{.data.license}'
 
 echo "deploying dashboard"
 kubectl apply -f "${PRODIR}/dashboard/dashboard.yaml" -n ${NAMESPACE}
-kubectl wait deployment/dashboard -n ${NAMESPACE} --for condition=available
+kubectl wait deployment/dashboard -n ${NAMESPACE} --for condition=available --timeout=${TIMEOUT}
 
 echo "deploying gateway"
 kubectl apply -f "${PRODIR}/gateway/gateway.yaml" -n ${NAMESPACE}
-kubectl wait deployment/tyk -n ${NAMESPACE} --for condition=available
+kubectl wait deployment/tyk -n ${NAMESPACE} --for condition=available --timeout=${TIMEOUT}
 
 echo "dashboard logs"
 kubectl logs svc/dashboard -n ${NAMESPACE}
@@ -51,4 +52,4 @@ kubectl logs svc/tyk -n ${NAMESPACE}
 
 echo "deploying httpbin as mock upstream to default ns"
 kubectl apply -f "${PWD}/ci/upstreams"
-kubectl wait deployment/httpbin --for condition=available
+kubectl wait deployment/httpbin --for condition=available --timeout=${TIMEOUT}

--- a/docs/api_definitions.md
+++ b/docs/api_definitions.md
@@ -74,6 +74,14 @@ An API Definition describes the configuration of an API. It instructs Tyk Gatewa
 | Tag Headers | ❌ | Not Implemented |
 | [Webhooks](./webhooks.md) | ❌ | [WIP #62](https://github.com/TykTechnologies/tyk-operator/issues/62) |
 
+# Pro features
+
+These are features which are only available to tyk PRO users
+
+| Feature | Supported | Comment |
+|---------|-----------|---------|
+| [Active API](./api_definitions/fields.md#active) |✅ | Untested|
+
 ## APIDefinition - Endpoint Middleware
 
 | Endpoint Middleware  | Supported | Comments |

--- a/docs/api_definitions/fields.md
+++ b/docs/api_definitions/fields.md
@@ -1,0 +1,31 @@
+This contains some comments /explanations about fields that are in the CRD on what
+they are used for.
+
+If you need to link anything into tables that needs additional explanation and is 
+a field in the APIDefinition resource it goes here.
+
+
+# active
+
+This determines whether the api definition will be loaded on the tyk gateway or not.
+
+Example
+
+```yaml
+apiVersion: tyk.tyk.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: httpbin
+spec:
+  name: httpbin
+  use_keyless: true
+  protocol: http
+  active: false
+  proxy:
+    target_url: http://httpbin.org
+    listen_path: /httpbin
+    strip_listen_path: true
+```
+
+A `httpbin` api will be created and stored in tyk pro but it will not be loaded on the gateways , calling the service will result in `404`
+

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -2,7 +2,7 @@
 
 - [Prerequisites](#prerequisites)
 - [Installing Tyk](#installing-tyk)
-- [Configuring Tyk Operator Secrets](#configuring-tyk-operator-secrets)
+- [Operator Configuration](#tyk-operator-configuration)
 - [Installing CRDs](#installing-crds)
 - [Installing cert-manager](#installing-cert-manager)
 - [Installing tyk-operator](#installing-tyk-operator)
@@ -27,7 +27,22 @@ The Tyk Installation does not need to be deployed inside K8s. You may already ha
 Using Tyk Operator, you can manage APIs in any Tyk installation whether self-hosted, K8s or Tyk Cloud. As long as the 
 management URL is accessible by the operator.
 
-### Configuring tyk-operator secrets
+### tyk-operator configuration
+
+Operator configurations are all stored in the secret `tyk-operator-conf`.
+
+#### Watching Namespaces
+
+Tyk Operator installs with cluster permissions, however you can optionally control which namespaces it watches by
+ by setting the `WATCH_NAMESPACE` environment variable.
+ 
+`WATCH_NAMESPACE` can be omitted entirely, or a comma separated list of k8s namespaces.
+
+- `WATCH_NAMESPACE=""` will watch for resources across the entire cluster.
+- `WATCH_NAMESPACE="foo"` will watch for resources in the `foo` namespace.
+- `WATCH_NAMESPACE="foo,bar"` will watch for resources in the `foo` and `bar` namespace. 
+
+#### connecting to Tyk
 
 tyk-operator needs to connect to a Tyk Pro deployment. And it needs to know whether it is talking to a Community
  Edition Gateway or Pro installation.
@@ -43,6 +58,7 @@ kubectl create secret -n tyk-operator-system generic tyk-operator-conf \
   --from-literal "TYK_MODE=${TYK_MODE}" \
   --from-literal "TYK_URL=${TYK_URL}"
 ```
+
 Examples of these values:
 
 |         | TYK_ORG     | TYK_AUTH       | TYK_URL            | TYK_MODE |
@@ -50,7 +66,6 @@ Examples of these values:
 | Tyk Pro | User Org ID, ie "5e9d9544a1dcd60001d0ed20" | User API Key, ie "2d095c2155774fe36d77e5cbe3ac963b"   | Dashboard Base URL, ie "http://localhost:3000" | "pro"    |
 | Tyk Hybrid | User Org ID | User API Key   | "https://admin.cloud.tyk.io/" | "pro"    |
 | Tyk OSS |      "foo"       | Gateway secret | Gateway Base URL   | "oss"    |
-
 
 And after you run the command, the values get automatically Base64 encoded:
 
@@ -71,7 +86,6 @@ Installing CRDs is as simple as checking out this repo & running `kubectl apply`
 ```bash
 kubectl apply -f ./helm/crds
 customresourcedefinition.apiextensions.k8s.io/apidefinitions.tyk.tyk.io configured
-customresourcedefinition.apiextensions.k8s.io/organizations.tyk.tyk.io configured
 customresourcedefinition.apiextensions.k8s.io/securitypolicies.tyk.tyk.io configured
 customresourcedefinition.apiextensions.k8s.io/webhooks.tyk.tyk.io configured
 ```

--- a/main.go
+++ b/main.go
@@ -174,13 +174,13 @@ func main() {
 		os.Exit(1)
 	}
 }
+// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+// which specifies the Namespace to watch.
+// An empty value means the operator is running with cluster scope.
+const watchNamespaceEnvVar = "WATCH_NAMESPACE"
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes
 func getWatchNamespace() (string, bool) {
-	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
-	// which specifies the Namespace to watch.
-	// An empty value means the operator is running with cluster scope.
-	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
 
 	return os.LookupEnv(watchNamespaceEnvVar)
 }

--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func main() {
 		os.Exit(1)
 	}
 }
+
 // WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
 // which specifies the Namespace to watch.
 // An empty value means the operator is running with cluster scope.
@@ -181,6 +182,10 @@ const watchNamespaceEnvVar = "WATCH_NAMESPACE"
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes
 func getWatchNamespace() (string, bool) {
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which specifies the Namespace to watch.
+	// An empty value means the operator is running with cluster scope.
+	const watchNamespaceEnvVar = "WATCH_NAMESPACE"
 
 	return os.LookupEnv(watchNamespaceEnvVar)
 }


### PR DESCRIPTION
Allows tyk-operator to watch `ALL`, `ONE` or `SPECIFIC` namespaces.

e.g. `team-a`, `team-b`, `team-c`, `team-d` might exist. But if the operator is only watching the `team-a` namespace, then APIDefinition and other Tyk custom resources will have 0 effect if they are outside of the operator's scope.

This facilitates having multiple namespace scoped operators deployed inside a single cluster.
By inference, multiple Tyk deployments or organisations inside a single cluster. We shall assume that a single operator operates on a single Tyk Organization.