### PR TITLE
scrap make rule surgery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ install-operator-helm: cross-build-image manifests helm
 	helm install ci ./helm --values ./ci/helm_values.yaml -n tyk-operator-system --wait
 
 .PHONY: scrap
-scrap: cross-build-image manifests helm
+scrap: generate manifests helm cross-build-image  
 	@echo "===> re installing operator with helm"
 	kind load docker-image ${IMG}
 	helm uninstall ci -n tyk-operator-system


### PR DESCRIPTION
`make scrap` was not generating `crd`.

This update scrape make rule by adding generate dependency. This also changes
the order of dependency from [cross-build-image => manifests => helm]
to [generate => manifests =>  helm => cross-build-image ] There is no
actual merit on the order change functional wise, it just makes more sense
and reflect well on what is happening.