### PR TITLE
add prerequisite for pro deployments

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -16,6 +16,12 @@ Before running the operator
 * A secret in the namespace of your operator deployment telling the operator how to communicate with Tyk
 * The CRDs must be registered with the Kubernetes apiserver
 * cert-manager must be installed
+* If you are using `pro` edition make sure in your gateway's `tyk.conf` `policies.allow_explicit_policy_id` is set to true
+```json
+    "policies": {
+        "allow_explicit_policy_id": true
+    },
+```
 
 ### Installing Tyk
 


### PR DESCRIPTION
```
    "policies": {
        "allow_explicit_policy_id": true
    },
```

Is required to be set in `tyk.conf` for SecurityPolicy resources to properly
work.

This is because the operator uses `id` to refer to security policy id's while
the gateways will by default use `_id` to refer to policy id's and when `policies.allow_explicit_policy_id` is true the gateway will use `id` when
it is provided to identify policies.
