### PR TITLE
Ourbound port exception for dash comms on istio

### DIFF
--- a/helm/templates/all.yaml
+++ b/helm/templates/all.yaml
@@ -199,6 +199,9 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: "3000"
+        traffic.sidecar.istio.io/includeOutboundPorts: ""
     spec:
       containers:
       - args:


### PR DESCRIPTION
When we use the operator in an injected namespace on Istio we will need to allow non intercepted requests to the dashboard (on port 3000 usually).

This annotation lets that happen when in that environment but does not change anything otherwise.

See related tyk-helm-chart PR that also brings this work together: https://github.com/TykTechnologies/tyk-helm-chart/pull/80

