### PR TITLE
Support podAnnotations

### DIFF
--- a/config/samples/istio/values.yaml
+++ b/config/samples/istio/values.yaml
@@ -1,0 +1,51 @@
+replicaCount: 1
+confSecretName: tyk-operator-conf
+
+image:
+  repository: tykio/tyk-operator
+  pullPolicy: IfNotPresent
+  tag: "test"
+
+rbacProxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: "v0.5.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "tyk-operator"
+
+annotations: {}
+podAnnotations:
+  traffic.sidecar.istio.io/excludeOutboundPorts: "3000"
+  traffic.sidecar.istio.io/includeOutboundPorts: ""
+podSecurityContext: {}
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+clusterDnsDomain: cluster.local

--- a/hack/helm/pre_helm.go
+++ b/hack/helm/pre_helm.go
@@ -17,6 +17,7 @@ func main() {
 		"imagePullPolicy: IfNotPresent": "imagePullPolicy: {{ .Values.image.pullPolicy }}",
 		"name: default":                 "name: {{ include \"tyk-operator-helm.serviceAccountName\" . }}",
 		"serviceAccountName: default":   "serviceAccountName: {{ include \"tyk-operator-helm.serviceAccountName\" . }}",
+		annotationsSrc:                  annotationsDest,
 	}
 	b, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
@@ -33,6 +34,20 @@ var resource = `{{- with .Values.resources}}
 {{- . | toYaml | nindent 10 }}
 {{end}}
 `
+
+const annotationsSrc = `  template:
+    metadata:
+      labels:
+        control-plane: controller-manager`
+
+const annotationsDest = `  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        control-plane: controller-manager`
 
 func injectResources(b []byte) []byte {
 	n := bytes.Index(b, []byte("kind: Deployment"))

--- a/helm/templates/all.yaml
+++ b/helm/templates/all.yaml
@@ -197,6 +197,10 @@ spec:
       control-plane: controller-manager
   template:
     metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
When podAnnotations is set inside `values.yaml` this will be picked up and
injected into the operator Deployment pod

sample `config/samples/istio/values.yaml`