### PR TITLE
simplify initialising client with TYK_TLS_INSECURE_SKIP_VERIFY

### DIFF
--- a/pkg/dashboard_client/client.go
+++ b/pkg/dashboard_client/client.go
@@ -35,7 +35,6 @@ type ResponseMsg struct {
 }
 
 func NewClient(log logr.Logger, env environmet.Env) *Client {
-	universal_client.SetInsecureSkipVerify(env)
 	return &Client{
 		Client: universal_client.Client{
 			Log: log,

--- a/pkg/gateway_client/client.go
+++ b/pkg/gateway_client/client.go
@@ -38,7 +38,6 @@ func NewClient(log logr.Logger, env environmet.Env) *Client {
 			},
 		},
 	}
-	universal_client.SetInsecureSkipVerify(env)
 	return c
 }
 

--- a/pkg/universal_client/client.go
+++ b/pkg/universal_client/client.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -45,27 +46,24 @@ var client = &http.Client{}
 
 var once sync.Once
 
-// SetInsecureSkipVerify creates transport that sets InsecureSkipVerify to true
-func SetInsecureSkipVerify(e environmet.Env) {
-	once.Do(func() {
-		if e.InsecureSkipVerify {
-			client.Transport = &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).DialContext,
-				ForceAttemptHTTP2:     true,
-				MaxIdleConns:          100,
-				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			}
+func init() {
+	if os.Getenv(environmet.SkipVerify) == "true" {
+		client.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
 		}
-	})
+	}
 }
 
 func JSON(res *http.Response, o interface{}) error {


### PR DESCRIPTION
There is no need of making this customizable. Since it is only set once
when the operator is started, init function fits better on this use case
