### PR TITLE
defect: mismatch b64 url encoding vs b64 raw url encoding

### DIFF
--- a/api/v1alpha1/apidefinition_types.go
+++ b/api/v1alpha1/apidefinition_types.go
@@ -213,7 +213,7 @@ type TargetInternal struct {
 
 func (i TargetInternal) String() string {
 	host := i.Target.String()
-	host = base64.URLEncoding.EncodeToString([]byte(host))
+	host = base64.RawURLEncoding.EncodeToString([]byte(host))
 	u := url.URL{
 		Scheme:   "tyk",
 		Host:     host,

--- a/controllers/apidefinition_controller.go
+++ b/controllers/apidefinition_controller.go
@@ -155,10 +155,8 @@ func (r *ApiDefinitionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		desired.Spec.APIID = desired.Status.ApiID
 		err = r.UniversalClient.Api().Update(&desired.Spec)
 		if err != nil {
-			if err != nil {
-				log.Error(err, "Failed to update api definition")
-				return err
-			}
+			log.Error(err, "Failed to update api definition")
+			return err
 		}
 		r.UniversalClient.HotReload()
 		return nil
@@ -287,7 +285,7 @@ func (r *ApiDefinitionReconciler) checkLinkedPolicies(ctx context.Context, a *ty
 }
 
 func encodeIfNotBase64(s string) string {
-	_, err := base64.URLEncoding.DecodeString(s)
+	_, err := base64.RawURLEncoding.DecodeString(s)
 	if err == nil {
 		return s
 	}

--- a/controllers/apidefinition_controller_test.go
+++ b/controllers/apidefinition_controller_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/base64"
 	"reflect"
 	"sort"
 	"testing"
@@ -199,5 +200,21 @@ func TestTargetInternal(t *testing.T) {
 	if expert, got := "tyk://ZGVmYXVsdC90ZXN0Mw/proxy/$1?a=1&b=2", target3.String(); expert != got {
 		t.Errorf("expected %q got %q", expert, got)
 	}
+}
 
+func TestEncodeIfNotBase64(t *testing.T) {
+	in := "default/httpbin-security-policy"
+	s := encodeIfNotBase64(in)
+	out, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if string(out) != in {
+		t.Fatal("out should be in")
+	}
+	in = "ZGVmYXVsdC9odHRwYmluLXNlY3VyaXR5LXBvbGljeQ"
+	s = encodeIfNotBase64(in)
+	if s != in {
+		t.Fatalf("expect %s, got %s", in, s)
+	}
 }


### PR DESCRIPTION
We should only b64 encode the linked policy, if it is not already b64 encoded.
We determine whether a string is b64 encoded or not by checking if
`base64.URLEncoding.Decode` returns an error. If it returns an error, then we know it is not
already encoded and we should base64 encode.

If it does not return an error, then we know that the string is already encoded, so we can just return
that string.

The problem is that we should be checking using `base64.RawURLEncoding.Decode`, not `base64.URLEncoding.Decode`
This is because we encode using `base64.RawURLEncoding.Encode`
