### PR TITLE
avoid updating access_rights_array on SecurityPolicySpec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ scrap: generate manifests helm cross-build-image
 	@echo "===> re installing operator with helm"
 	go run hack/cluster/load_image.go -image ${IMG} -cluster=${CLUSTER_NAME}
 	helm uninstall ci -n tyk-operator-system
+	kubectl apply -f ./helm/crds
 	helm install ci ./helm --values ./ci/helm_values.yaml -n tyk-operator-system --wait
 
 .PHONY: setup-pro

--- a/api/v1alpha1/securitypolicy_types.go
+++ b/api/v1alpha1/securitypolicy_types.go
@@ -48,7 +48,7 @@ type SecurityPolicySpec struct {
 
 	// IsInactive applies to the key itself. Allows enabling or disabling the policy without deleting it.
 	IsInactive        bool                        `json:"is_inactive,omitempty"`
-	AccessRightsArray []AccessDefinition          `json:"access_rights_array"`
+	AccessRightsArray []*AccessDefinition         `json:"access_rights_array,omitempty"`
 	AccessRights      map[string]AccessDefinition `json:"access_rights,omitempty"`
 
 	// Rate limit per X seconds (x="Per"), omit or "-1" for unlimited
@@ -79,8 +79,8 @@ type SecurityPolicySpec struct {
 	Tags []string `json:"tags,omitempty"`
 
 	// KeyExpiresIn is the number of seconds till key expiry. For 1 hour is 3600. Default never expire or 0
-	KeyExpiresIn int64            `json:"key_expires_in,omitempty"`
-	Partitions   PolicyPartitions `json:"partitions,omitempty"`
+	KeyExpiresIn int64             `json:"key_expires_in,omitempty"`
+	Partitions   *PolicyPartitions `json:"partitions,omitempty"`
 
 	//LastUpdated                   string                           `json:"last_updated"`
 	MetaData map[string]string `json:"meta_data,omitempty"`
@@ -99,7 +99,7 @@ type AccessDefinition struct {
 	APIName string `json:"api_name,omitempty"`
 	// TODO: APIID should not really be needed, as is auto-set from the APIDefnition Resource
 	APIID    string   `json:"api_id,omitempty"`
-	Versions []string `json:"versions"`
+	Versions []string `json:"versions,omitempty"`
 	//RestrictedTypes []graphql.Type `json:"restricted_types"`
 	//Limit          APILimit     `json:"limit,omitempty"`
 	AllowanceScope string       `json:"allowance_scope,omitempty"`

--- a/api/v1alpha1/securitypolicy_webhook.go
+++ b/api/v1alpha1/securitypolicy_webhook.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"os"
-	"strings"
 
 	"github.com/TykTechnologies/tyk-operator/pkg/environmet"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,7 +37,7 @@ func (r *SecurityPolicy) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-tyk-tyk-io-v1alpha1-securitypolicy,mutating=true,failurePolicy=fail,groups=tyk.tyk.io,resources=securitypolicies,verbs=create;update,versions=v1alpha1,name=msecuritypolicy.kb.io
+// +kubebuilder:webhook:path=/mutate-tyk-tyk-io-v1alpha1-securitypolicy,mutating=true,failurePolicy=fail,groups=tyk.tyk.io,resources=securitypolicies,verbs=create;update,versions=v1alpha1,name=msecuritypolicy.kb.io,sideEffects=None
 
 var _ webhook.Defaulter = &SecurityPolicy{}
 
@@ -52,11 +51,11 @@ func (r *SecurityPolicy) Default() {
 	spec.ThrottleRetryLimit = -1
 	spec.QuotaMax = -1
 	spec.QuotaRenewalRate = -1
-	spec.OrgID = strings.TrimSpace(os.Getenv(environmet.TykORG))
+	spec.OrgID = os.Getenv(environmet.TykORG)
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-tyk-tyk-io-v1alpha1-securitypolicy,mutating=false,failurePolicy=fail,groups=tyk.tyk.io,resources=securitypolicies,versions=v1alpha1,name=vsecuritypolicy.kb.io
+// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-tyk-tyk-io-v1alpha1-securitypolicy,mutating=false,failurePolicy=fail,groups=tyk.tyk.io,resources=securitypolicies,versions=v1alpha1,name=vsecuritypolicy.kb.io,sideEffects=None
 
 var _ webhook.Validator = &SecurityPolicy{}
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1483,9 +1483,13 @@ func (in *SecurityPolicySpec) DeepCopyInto(out *SecurityPolicySpec) {
 	*out = *in
 	if in.AccessRightsArray != nil {
 		in, out := &in.AccessRightsArray, &out.AccessRightsArray
-		*out = make([]AccessDefinition, len(*in))
+		*out = make([]*AccessDefinition, len(*in))
 		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(AccessDefinition)
+				(*in).DeepCopyInto(*out)
+			}
 		}
 	}
 	if in.AccessRights != nil {
@@ -1500,7 +1504,11 @@ func (in *SecurityPolicySpec) DeepCopyInto(out *SecurityPolicySpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.Partitions = in.Partitions
+	if in.Partitions != nil {
+		in, out := &in.Partitions, &out.Partitions
+		*out = new(PolicyPartitions)
+		**out = **in
+	}
 	if in.MetaData != nil {
 		in, out := &in.MetaData, &out.MetaData
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/tyk.tyk.io_securitypolicies.yaml
+++ b/config/crd/bases/tyk.tyk.io_securitypolicies.yaml
@@ -88,7 +88,6 @@ spec:
                 required:
                 - name
                 - namespace
-                - versions
                 type: object
               type: object
             access_rights_array:
@@ -137,7 +136,6 @@ spec:
                 required:
                 - name
                 - namespace
-                - versions
                 type: object
               type: array
             active:
@@ -239,7 +237,6 @@ spec:
                 for unlimited
               type: integer
           required:
-          - access_rights_array
           - active
           - name
           - state

--- a/config/samples/httpbin_protected_policy.yaml
+++ b/config/samples/httpbin_protected_policy.yaml
@@ -12,22 +12,8 @@ spec:
       versions:
         - Default
 
-# TODO: Think about defaulting so we don't have to set these values to -1
-  per: -1
-  quota_max: -1
-  quota_renewal_rate: -1
-  rate: -1
-  throttle_interval: -1
-  throttle_retry_limit: -1
-  max_query_depth: -1
-
-  key_expires_in: 0
-  tags: []
-
-# TODO: can we set sensible defaults for partitions?
+  # TODO: can we set sensible defaults for partitions?
   partitions:
     quota: true
     rate_limit: true
     acl: true
-    complexity: false
-    per_api: false

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -43,6 +43,7 @@ webhooks:
     - UPDATE
     resources:
     - securitypolicies
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -89,3 +90,4 @@ webhooks:
     - DELETE
     resources:
     - securitypolicies
+  sideEffects: None

--- a/helm/crds/crds.yaml
+++ b/helm/crds/crds.yaml
@@ -1665,7 +1665,6 @@ spec:
                 required:
                 - name
                 - namespace
-                - versions
                 type: object
               type: object
             access_rights_array:
@@ -1709,7 +1708,6 @@ spec:
                 required:
                 - name
                 - namespace
-                - versions
                 type: object
               type: array
             active:
@@ -1798,7 +1796,6 @@ spec:
               description: Number of retries before returning error.   omit or "-1" for unlimited
               type: integer
           required:
-          - access_rights_array
           - active
           - name
           - state

--- a/helm/templates/all.yaml
+++ b/helm/templates/all.yaml
@@ -312,6 +312,7 @@ webhooks:
     - UPDATE
     resources:
     - securitypolicies
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
@@ -358,3 +359,4 @@ webhooks:
     - DELETE
     resources:
     - securitypolicies
+  sideEffects: None


### PR DESCRIPTION
Fixes #250

any updates on this object confused k8s diff even when the object didn't
change.

In this commit, we only update the copy that is sent to the dashboard for 
Update and Create calls. The dashboard will receive the objects with 
`api_name` and `api_id` properly set, however these will not be stored in
k8s since we already refer to the referenced api by name and namespace 
and they serve no other purpose.

This means kubectl apply will return unchanged when the resource hasn't changed.

<img width="923" alt="Screen Shot 2021-05-05 at 14 31 26" src="https://user-images.githubusercontent.com/6039952/117134768-accd9100-adae-11eb-97e9-3c34b436aa78.png">
