### PR TITLE
chore: use context.Context in universal client

### DIFF
--- a/controllers/apidefinition_controller.go
+++ b/controllers/apidefinition_controller.go
@@ -138,7 +138,7 @@ func (r *ApiDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		desired.Spec.CollectLoopingTarget()
 		//  If this is not set, means it is a new object, set it first
 		if desired.Status.ApiID == "" {
-			err := r.UniversalClient.Api().Create(&desired.Spec)
+			err := r.UniversalClient.Api().Create(ctx, &desired.Spec)
 			if err != nil {
 				log.Error(err, "Failed to create api definition")
 				return err
@@ -153,7 +153,7 @@ func (r *ApiDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		log.Info("Updating ApiDefinition")
 		desired.Spec.APIID = desired.Status.ApiID
-		err = r.UniversalClient.Api().Update(&desired.Spec)
+		err = r.UniversalClient.Api().Update(ctx, &desired.Spec)
 		if err != nil {
 			log.Error(err, "Failed to update api definition")
 			return err
@@ -251,7 +251,7 @@ func (r *ApiDefinitionReconciler) delete(ctx context.Context, desired *tykv1alph
 			}
 		}
 		r.Log.Info("deleting api")
-		err := r.UniversalClient.Api().Delete(desired.Status.ApiID)
+		err := r.UniversalClient.Api().Delete(ctx, desired.Status.ApiID)
 		if err != nil {
 			r.Log.Error(err, "unable to delete api", "api_id", desired.Status.ApiID)
 			return 0, err

--- a/controllers/apidefinition_controller.go
+++ b/controllers/apidefinition_controller.go
@@ -110,10 +110,10 @@ func (r *ApiDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 
 			tykCertID := r.UniversalClient.Organization().GetID() + cert.CalculateFingerPrint(pemCrtBytes)
-			exists := r.UniversalClient.Certificate().Exists(tykCertID)
+			exists := r.UniversalClient.Certificate().Exists(ctx, tykCertID)
 			if !exists {
 				// upload the certificate
-				tykCertID, err = r.UniversalClient.Certificate().Upload(pemKeyBytes, pemCrtBytes)
+				tykCertID, err = r.UniversalClient.Certificate().Upload(ctx, pemKeyBytes, pemCrtBytes)
 				if err != nil {
 					queue = true
 					return err

--- a/controllers/secret_cert_controller.go
+++ b/controllers/secret_cert_controller.go
@@ -72,7 +72,7 @@ func (r *SecretCertReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			certID := orgID + certFingerPrint
 
 			log.Info("deleting certificate from tyk certificate manager", "orgID", orgID, "fingerprint", certFingerPrint)
-			if err := r.UniversalClient.Certificate().Delete(certID); err != nil {
+			if err := r.UniversalClient.Certificate().Delete(ctx, certID); err != nil {
 				log.Error(err, "unable to delete certificate")
 				return ctrl.Result{RequeueAfter: time.Second * 5}, err
 			}
@@ -151,7 +151,7 @@ func (r *SecretCertReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	certID, err := r.UniversalClient.Certificate().Upload(tlsKey, tlsCrt)
+	certID, err := r.UniversalClient.Certificate().Upload(ctx, tlsKey, tlsCrt)
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}

--- a/controllers/secret_cert_controller.go
+++ b/controllers/secret_cert_controller.go
@@ -161,10 +161,10 @@ func (r *SecretCertReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if containsString(apiDef.Spec.CertificateSecretNames, req.Name) {
 			log.Info("replacing certificate", "apiID", apiDef.Status.ApiID, "certID", certID)
 
-			apiDefObj, _ := r.UniversalClient.Api().Get(apiDef.Status.ApiID)
+			apiDefObj, _ := r.UniversalClient.Api().Get(ctx, apiDef.Status.ApiID)
 			apiDefObj.Certificates = []string{}
 			apiDefObj.Certificates = append(apiDefObj.Certificates, certID)
-			r.UniversalClient.Api().Update(apiDefObj)
+			r.UniversalClient.Api().Update(ctx, apiDefObj)
 
 			// TODO: we only care about 1 secret - we don't need to support multiple for mvp
 			break

--- a/controllers/securitypolicy_controller.go
+++ b/controllers/securitypolicy_controller.go
@@ -121,7 +121,7 @@ func (r *SecurityPolicyReconciler) updateAccess(ctx context.Context,
 func (r *SecurityPolicyReconciler) delete(ctx context.Context, policy *tykv1.SecurityPolicy) error {
 	r.Log.Info("Deleting policy")
 	util.RemoveFinalizer(policy, policyFinalizer)
-	if err := r.UniversalClient.SecurityPolicy().Delete(policy.Status.PolID); err != nil {
+	if err := r.UniversalClient.SecurityPolicy().Delete(ctx, policy.Status.PolID); err != nil {
 		if universal_client.IsNotFound(err) {
 			r.Log.Info("Policy not found")
 			return nil
@@ -146,7 +146,7 @@ func (r *SecurityPolicyReconciler) update(ctx context.Context, policy *tykv1.Sec
 	if err != nil {
 		return err
 	}
-	err = r.UniversalClient.SecurityPolicy().Update(spec)
+	err = r.UniversalClient.SecurityPolicy().Update(ctx, spec)
 	if err != nil {
 		r.Log.Error(err, "Failed to update policy")
 		return err
@@ -168,7 +168,7 @@ func (r *SecurityPolicyReconciler) create(ctx context.Context, policy *tykv1.Sec
 	if err != nil {
 		return err
 	}
-	err = r.UniversalClient.SecurityPolicy().Create(spec)
+	err = r.UniversalClient.SecurityPolicy().Create(ctx, spec)
 	if err != nil {
 		r.Log.Error(err, "Failed to create policy")
 		return err

--- a/controllers/securitypolicy_controller.go
+++ b/controllers/securitypolicy_controller.go
@@ -109,7 +109,7 @@ func (r *SecurityPolicyReconciler) updateAccess(ctx context.Context,
 		r.Log.Error(err, "Failed to get APIDefinition to attach to SecurityPolicy")
 		return err
 	}
-	def, err := r.UniversalClient.Api().Get(api.Status.ApiID)
+	def, err := r.UniversalClient.Api().Get(ctx, api.Status.ApiID)
 	if err != nil {
 		return err
 	}

--- a/pkg/dashboard_client/api.go
+++ b/pkg/dashboard_client/api.go
@@ -1,6 +1,7 @@
 package dashboard_client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -12,7 +13,7 @@ type Api struct {
 	*Client
 }
 
-func (a Api) All() ([]tykv1alpha1.APIDefinitionSpec, error) {
+func (a Api) All(ctx context.Context) ([]tykv1alpha1.APIDefinitionSpec, error) {
 	res, err := a.Client.Get(a.Env.JoinURL(endpointAPIs), nil,
 		universal_client.AddQuery(map[string]string{
 			"p": "-2",
@@ -42,7 +43,7 @@ func (a Api) All() ([]tykv1alpha1.APIDefinitionSpec, error) {
 	return list, nil
 }
 
-func (a Api) Create(def *tykv1alpha1.APIDefinitionSpec) error {
+func (a Api) Create(ctx context.Context, def *tykv1alpha1.APIDefinitionSpec) error {
 	res, err := a.Client.PostJSON(a.Env.JoinURL(endpointAPIs),
 		DashboardApi{
 			ApiDefinition: *def,
@@ -70,8 +71,8 @@ func (a Api) Create(def *tykv1alpha1.APIDefinitionSpec) error {
 	return a.update(*o)
 }
 
-func (a Api) Get(id string) (*tykv1alpha1.APIDefinitionSpec, error) {
-	all, err := a.All()
+func (a Api) Get(ctx context.Context, id string) (*tykv1alpha1.APIDefinitionSpec, error) {
+	all, err := a.All(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +100,8 @@ func (a Api) get(id string) (*tykv1alpha1.APIDefinitionSpec, error) {
 	return &resMsg.ApiDefinition, nil
 }
 
-func (a Api) Update(def *tykv1alpha1.APIDefinitionSpec) error {
-	x, err := a.Get(def.APIID)
+func (a Api) Update(ctx context.Context, def *tykv1alpha1.APIDefinitionSpec) error {
+	x, err := a.Get(ctx, def.APIID)
 	if err != nil {
 		return err
 	}
@@ -134,8 +135,8 @@ func (a Api) update(o tykv1alpha1.APIDefinitionSpec) error {
 	return nil
 }
 
-func (a Api) Delete(id string) error {
-	x, err := a.Get(id)
+func (a Api) Delete(ctx context.Context, id string) error {
+	x, err := a.Get(ctx, id)
 	if err != nil {
 		return universal_client.IgnoreNotFound(err)
 	}

--- a/pkg/dashboard_client/api_test.go
+++ b/pkg/dashboard_client/api_test.go
@@ -1,6 +1,7 @@
 package dashboard_client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -189,13 +190,13 @@ func TestAPI(t *testing.T) {
 
 func requestAPI(t *testing.T, e environmet.Env, name string, kase ...universal_client.Kase) {
 	t.Helper()
-
+	ctx := context.TODO()
 	t.Run(name, func(t *testing.T) {
 		switch name {
 		case "All":
 			universal_client.RunRequestKase(t, e,
 				func(c universal_client.Client) error {
-					newKlient(c).Api().All()
+					newKlient(c).Api().All(ctx)
 					return nil
 				},
 				kase...,
@@ -203,7 +204,7 @@ func requestAPI(t *testing.T, e environmet.Env, name string, kase ...universal_c
 		case "Get":
 			universal_client.RunRequestKase(t, e,
 				func(c universal_client.Client) error {
-					newKlient(c).Api().Get(testAPIID)
+					newKlient(c).Api().Get(ctx, testAPIID)
 					return nil
 				},
 				kase...,
@@ -213,7 +214,7 @@ func requestAPI(t *testing.T, e environmet.Env, name string, kase ...universal_c
 				func(c universal_client.Client) error {
 					var s v1alpha1.APIDefinitionSpec
 					Sample(t, "api."+name, &s)
-					newKlient(c).Api().Update(&s)
+					newKlient(c).Api().Update(ctx, &s)
 					return nil
 				},
 				kase...,
@@ -223,7 +224,7 @@ func requestAPI(t *testing.T, e environmet.Env, name string, kase ...universal_c
 				func(c universal_client.Client) error {
 					var s v1alpha1.APIDefinitionSpec
 					Sample(t, "api."+name, &s)
-					newKlient(c).Api().Create(&s)
+					newKlient(c).Api().Create(ctx, &s)
 					return nil
 				},
 				kase...,
@@ -231,7 +232,7 @@ func requestAPI(t *testing.T, e environmet.Env, name string, kase ...universal_c
 		case "Delete":
 			universal_client.RunRequestKase(t, e,
 				func(c universal_client.Client) error {
-					newKlient(c).Api().Delete(testAPIID)
+					newKlient(c).Api().Delete(ctx, testAPIID)
 					return nil
 				},
 				kase...,

--- a/pkg/dashboard_client/cert.go
+++ b/pkg/dashboard_client/cert.go
@@ -2,6 +2,7 @@ package dashboard_client
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -21,7 +22,7 @@ type CertificateList struct {
 }
 
 // All returns a list of all certificates ID's
-func (c *Cert) All() ([]string, error) {
+func (c *Cert) All(ctx context.Context) ([]string, error) {
 	res, err := c.Client.Get(c.Env.JoinURL(endpointCerts), nil)
 	if err != nil {
 		return nil, err
@@ -38,7 +39,7 @@ func (c *Cert) All() ([]string, error) {
 	return o.CertIDs, nil
 }
 
-func (c *Cert) Exists(id string) bool {
+func (c *Cert) Exists(ctx context.Context, id string) bool {
 	res, err := c.Client.Get(c.Env.JoinURL(endpointCerts, id), nil)
 	if err != nil {
 		c.Log.Error(err, "failed to get certificate")
@@ -52,7 +53,7 @@ func (c *Cert) Exists(id string) bool {
 	return true
 }
 
-func (c *Cert) Delete(id string) error {
+func (c *Cert) Delete(ctx context.Context, id string) error {
 	res, err := c.Client.Delete(c.Env.JoinURL(endpointCerts, id), nil)
 	if err != nil {
 		return err
@@ -64,7 +65,7 @@ func (c *Cert) Delete(id string) error {
 	return nil
 }
 
-func (c *Cert) Upload(key []byte, crt []byte) (id string, err error) {
+func (c *Cert) Upload(ctx context.Context, key []byte, crt []byte) (id string, err error) {
 	combined := make([]byte, 0)
 	combined = append(combined, key...)
 	combined = append(combined, crt...)

--- a/pkg/dashboard_client/cert_test.go
+++ b/pkg/dashboard_client/cert_test.go
@@ -1,6 +1,7 @@
 package dashboard_client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -88,11 +89,12 @@ func TestCert(t *testing.T) {
 
 func requestCert(t *testing.T, e environmet.Env, kase universal_client.Kase) {
 	t.Helper()
+	ctx := context.TODO()
 	switch kase.Name {
 	case "All":
 		universal_client.RunRequestKase(t, e,
 			func(c universal_client.Client) error {
-				newKlient(c).Certificate().All()
+				newKlient(c).Certificate().All(ctx)
 				return nil
 			},
 			kase,
@@ -102,7 +104,7 @@ func requestCert(t *testing.T, e environmet.Env, kase universal_client.Kase) {
 			func(c universal_client.Client) error {
 				key := ReadSampleFile(t, "cert.Key.pem")
 				cert := ReadSampleFile(t, "cert.Cert.pem")
-				newKlient(c).Certificate().Upload([]byte(key), []byte(cert))
+				newKlient(c).Certificate().Upload(ctx, []byte(key), []byte(cert))
 				return nil
 			},
 			kase,
@@ -110,7 +112,7 @@ func requestCert(t *testing.T, e environmet.Env, kase universal_client.Kase) {
 	case "Exist":
 		universal_client.RunRequestKase(t, e,
 			func(c universal_client.Client) error {
-				newKlient(c).Certificate().Exists(testCertID)
+				newKlient(c).Certificate().Exists(ctx, testCertID)
 				return nil
 			},
 			kase,

--- a/pkg/dashboard_client/security_policy.go
+++ b/pkg/dashboard_client/security_policy.go
@@ -1,6 +1,7 @@
 package dashboard_client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,7 +15,7 @@ type SecurityPolicy struct {
 }
 
 // All Returns all policies from the Dashboard
-func (p SecurityPolicy) All() ([]v1.SecurityPolicySpec, error) {
+func (p SecurityPolicy) All(ctx context.Context) ([]v1.SecurityPolicySpec, error) {
 	res, err := p.Client.Get(p.Env.JoinURL(endpointPolicies), nil)
 	if err != nil {
 		return nil, err
@@ -33,7 +34,7 @@ func (p SecurityPolicy) All() ([]v1.SecurityPolicySpec, error) {
 }
 
 // Get  find the Policy by id
-func (p SecurityPolicy) Get(id string) (*v1.SecurityPolicySpec, error) {
+func (p SecurityPolicy) Get(ctx context.Context, id string) (*v1.SecurityPolicySpec, error) {
 	res, err := p.Client.Get(p.Env.JoinURL(endpointPolicies, id), nil)
 	if err != nil {
 		return nil, err
@@ -47,7 +48,7 @@ func (p SecurityPolicy) Get(id string) (*v1.SecurityPolicySpec, error) {
 }
 
 // Create  creates a new policy using the def object
-func (p SecurityPolicy) Create(def *v1.SecurityPolicySpec) error {
+func (p SecurityPolicy) Create(ctx context.Context, def *v1.SecurityPolicySpec) error {
 	res, err := p.Client.PostJSON(p.Env.JoinURL(endpointPolicies), def)
 	if err != nil {
 		return err
@@ -70,7 +71,7 @@ func (p SecurityPolicy) Create(def *v1.SecurityPolicySpec) error {
 }
 
 // Update updates a resource object def
-func (p SecurityPolicy) Update(def *v1.SecurityPolicySpec) error {
+func (p SecurityPolicy) Update(ctx context.Context, def *v1.SecurityPolicySpec) error {
 	res, err := p.Client.PutJSON(p.Env.JoinURL(endpointPolicies, def.MID), def)
 	if err != nil {
 		return err
@@ -83,7 +84,7 @@ func (p SecurityPolicy) Update(def *v1.SecurityPolicySpec) error {
 }
 
 // Delete deletes the resource by ID
-func (p SecurityPolicy) Delete(id string) error {
+func (p SecurityPolicy) Delete(ctx context.Context, id string) error {
 	res, err := p.Client.Delete(p.Env.JoinURL(endpointPolicies, id), nil)
 	if err != nil {
 		return err

--- a/pkg/dashboard_client/security_policy_test.go
+++ b/pkg/dashboard_client/security_policy_test.go
@@ -1,6 +1,7 @@
 package dashboard_client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -123,11 +124,12 @@ func TestSecurityPolicy(t *testing.T) {
 
 func requestSecurityPolicy(t *testing.T, e environmet.Env, kase universal_client.Kase) {
 	t.Helper()
+	ctx := context.TODO()
 	switch kase.Name {
 	case "All":
 		universal_client.RunRequestKase(t, e,
 			func(c universal_client.Client) error {
-				newKlient(c).SecurityPolicy().All()
+				newKlient(c).SecurityPolicy().All(ctx)
 				return nil
 			},
 			kase,
@@ -135,7 +137,7 @@ func requestSecurityPolicy(t *testing.T, e environmet.Env, kase universal_client
 	case "Get":
 		universal_client.RunRequestKase(t, e,
 			func(c universal_client.Client) error {
-				newKlient(c).SecurityPolicy().Get(testSecurityPolicyID)
+				newKlient(c).SecurityPolicy().Get(ctx, testSecurityPolicyID)
 				return nil
 			},
 			kase,
@@ -145,7 +147,7 @@ func requestSecurityPolicy(t *testing.T, e environmet.Env, kase universal_client
 			func(c universal_client.Client) error {
 				var s v1alpha1.SecurityPolicySpec
 				Sample(t, "policy."+kase.Name, &s)
-				newKlient(c).SecurityPolicy().Update(&s)
+				newKlient(c).SecurityPolicy().Update(ctx, &s)
 				return nil
 			},
 			kase,
@@ -155,7 +157,7 @@ func requestSecurityPolicy(t *testing.T, e environmet.Env, kase universal_client
 			func(c universal_client.Client) error {
 				var s v1alpha1.SecurityPolicySpec
 				Sample(t, "policy."+kase.Name, &s)
-				newKlient(c).SecurityPolicy().Create(&s)
+				newKlient(c).SecurityPolicy().Create(ctx, &s)
 				return nil
 			},
 			kase,
@@ -163,7 +165,7 @@ func requestSecurityPolicy(t *testing.T, e environmet.Env, kase universal_client
 	case "Delete":
 		universal_client.RunRequestKase(t, e,
 			func(c universal_client.Client) error {
-				newKlient(c).SecurityPolicy().Delete(testSecurityPolicyID)
+				newKlient(c).SecurityPolicy().Delete(ctx, testSecurityPolicyID)
 				return nil
 			},
 			kase,

--- a/pkg/gateway_client/api.go
+++ b/pkg/gateway_client/api.go
@@ -1,6 +1,7 @@
 package gateway_client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -17,7 +18,7 @@ type Api struct {
 	*Client
 }
 
-func (a Api) All() ([]v1.APIDefinitionSpec, error) {
+func (a Api) All(ctx context.Context) ([]v1.APIDefinitionSpec, error) {
 	res, err := a.Client.Get(a.Env.JoinURL(endpointAPIs), nil)
 	if err != nil {
 		return nil, err
@@ -35,7 +36,7 @@ func (a Api) All() ([]v1.APIDefinitionSpec, error) {
 	return list, nil
 }
 
-func (a Api) Get(apiID string) (*v1.APIDefinitionSpec, error) {
+func (a Api) Get(ctx context.Context, apiID string) (*v1.APIDefinitionSpec, error) {
 	res, err := a.Client.Get(a.Env.JoinURL(endpointAPIs, apiID), nil)
 	if err != nil {
 		return nil, err
@@ -51,7 +52,7 @@ func (a Api) Get(apiID string) (*v1.APIDefinitionSpec, error) {
 	return &spec, nil
 }
 
-func (a Api) Create(def *v1.APIDefinitionSpec) error {
+func (a Api) Create(ctx context.Context, def *v1.APIDefinitionSpec) error {
 	res, err := a.PostJSON(a.Env.JoinURL(endpointAPIs), def)
 	if err != nil {
 		return err
@@ -68,7 +69,7 @@ func (a Api) Create(def *v1.APIDefinitionSpec) error {
 	return nil
 }
 
-func (a Api) Update(def *v1.APIDefinitionSpec) error {
+func (a Api) Update(ctx context.Context, def *v1.APIDefinitionSpec) error {
 	res, err := a.PutJSON(a.Env.JoinURL(endpointAPIs, def.APIID), def)
 	if err != nil {
 		return err
@@ -84,7 +85,7 @@ func (a Api) Update(def *v1.APIDefinitionSpec) error {
 	return nil
 }
 
-func (a Api) Delete(id string) error {
+func (a Api) Delete(ctx context.Context, id string) error {
 	res, err := a.Client.Delete(a.Env.JoinURL(endpointAPIs, id), nil)
 	if err != nil {
 		return err

--- a/pkg/gateway_client/security_policy.go
+++ b/pkg/gateway_client/security_policy.go
@@ -1,6 +1,8 @@
 package gateway_client
 
 import (
+	"context"
+
 	v1 "github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 	"github.com/TykTechnologies/tyk-operator/pkg/universal_client"
 )
@@ -11,22 +13,22 @@ import (
 type SecurityPolicy struct {
 }
 
-func (a SecurityPolicy) All() ([]v1.SecurityPolicySpec, error) {
+func (a SecurityPolicy) All(ctx context.Context) ([]v1.SecurityPolicySpec, error) {
 	return nil, universal_client.ErrTODO
 }
 
-func (a SecurityPolicy) Get(namespacedName string) (*v1.SecurityPolicySpec, error) {
+func (a SecurityPolicy) Get(ctx context.Context, namespacedName string) (*v1.SecurityPolicySpec, error) {
 	return nil, universal_client.ErrTODO
 }
 
-func (a SecurityPolicy) Create(def *v1.SecurityPolicySpec) error {
+func (a SecurityPolicy) Create(ctx context.Context, def *v1.SecurityPolicySpec) error {
 	return universal_client.ErrTODO
 }
 
-func (a SecurityPolicy) Update(def *v1.SecurityPolicySpec) error {
+func (a SecurityPolicy) Update(ctx context.Context, def *v1.SecurityPolicySpec) error {
 	return universal_client.ErrTODO
 }
 
-func (a SecurityPolicy) Delete(namespacedName string) error {
+func (a SecurityPolicy) Delete(ctx context.Context, namespacedName string) error {
 	return universal_client.ErrTODO
 }

--- a/pkg/universal_client/api.go
+++ b/pkg/universal_client/api.go
@@ -1,13 +1,15 @@
 package universal_client
 
 import (
+	"context"
+
 	v1 "github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 )
 
 type UniversalApi interface {
-	Get(apiID string) (*v1.APIDefinitionSpec, error)
-	All() ([]v1.APIDefinitionSpec, error)
-	Create(spec *v1.APIDefinitionSpec) error
-	Update(def *v1.APIDefinitionSpec) error
-	Delete(id string) error
+	Get(ctx context.Context, apiID string) (*v1.APIDefinitionSpec, error)
+	All(ctx context.Context) ([]v1.APIDefinitionSpec, error)
+	Create(ctx context.Context, spec *v1.APIDefinitionSpec) error
+	Update(ctx context.Context, def *v1.APIDefinitionSpec) error
+	Delete(ctx context.Context, id string) error
 }

--- a/pkg/universal_client/certificate.go
+++ b/pkg/universal_client/certificate.go
@@ -1,9 +1,11 @@
 package universal_client
 
+import "context"
+
 type UniversalCertificate interface {
-	All() ([]string, error)
-	Upload(key []byte, crt []byte) (id string, err error)
-	Delete(id string) error
+	All(ctx context.Context) ([]string, error)
+	Upload(ctx context.Context, key []byte, crt []byte) (id string, err error)
+	Delete(ctx context.Context, id string) error
 	// Exists returns true if a certificate with id exists
-	Exists(id string) bool
+	Exists(ctx context.Context, id string) bool
 }

--- a/pkg/universal_client/security_policy.go
+++ b/pkg/universal_client/security_policy.go
@@ -1,19 +1,21 @@
 package universal_client
 
 import (
+	"context"
+
 	tykv1alpha1 "github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 )
 
 type UniversalSecurityPolicy interface {
-	All() ([]tykv1alpha1.SecurityPolicySpec, error)
+	All(ctx context.Context) ([]tykv1alpha1.SecurityPolicySpec, error)
 	// Get retruns the policy with the given id.
-	Get(id string) (*tykv1alpha1.SecurityPolicySpec, error)
+	Get(ctx context.Context, id string) (*tykv1alpha1.SecurityPolicySpec, error)
 	// Create creates a new def and updates id and other fields. It is up to the
 	// caller to update any fields that will be set after the policy has been
 	// created for instance _id
-	Create(def *tykv1alpha1.SecurityPolicySpec) error
+	Create(ctx context.Context, def *tykv1alpha1.SecurityPolicySpec) error
 	// Update this will update an existing policy
-	Update(def *tykv1alpha1.SecurityPolicySpec) error
+	Update(ctx context.Context, def *tykv1alpha1.SecurityPolicySpec) error
 	//Delete deletes policy id id
-	Delete(id string) error
+	Delete(ctx context.Context, id string) error
 }


### PR DESCRIPTION
This PR updates  interfaces exposed by Universal client to use `context.Context`

## Why ?
Context awareness helps in

- properly manage http.Client (Timeouts/deadlines and cancelation)
- resource cleanup (in case of offloading expensive ops in goroutines)
- raise awareness of execution environment . This is important since we are now thinking about multi tenancy.

The interfaces updated are `UniversalApi` `UniversalCertificate` and `UniversalSecurityPolicy`