### PR TITLE
add custom_middleware_bundle on APIDefinitionSpec

### DIFF
--- a/api/v1alpha1/apidefinition_types.go
+++ b/api/v1alpha1/apidefinition_types.go
@@ -627,8 +627,8 @@ type APIDefinitionSpec struct {
 	//DisableRateLimit       bool                `json:"disable_rate_limit"`
 	//DisableQuota           bool                `json:"disable_quota"`
 
-	CustomMiddleware MiddlewareSection `json:"custom_middleware,omitempty"`
-	//CustomMiddlewareBundle string              `json:"custom_middleware_bundle"`
+	CustomMiddleware       MiddlewareSection `json:"custom_middleware,omitempty"`
+	CustomMiddlewareBundle string            `json:"custom_middleware_bundle"`
 
 	CacheOptions CacheOptions `json:"cache_options,omitempty"`
 

--- a/api/v1alpha1/apidefinition_types.go
+++ b/api/v1alpha1/apidefinition_types.go
@@ -628,7 +628,7 @@ type APIDefinitionSpec struct {
 	//DisableQuota           bool                `json:"disable_quota"`
 
 	CustomMiddleware       MiddlewareSection `json:"custom_middleware,omitempty"`
-	CustomMiddlewareBundle string            `json:"custom_middleware_bundle"`
+	CustomMiddlewareBundle string            `json:"custom_middleware_bundle,omitempty"`
 
 	CacheOptions CacheOptions `json:"cache_options,omitempty"`
 

--- a/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
+++ b/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
@@ -383,6 +383,8 @@ spec:
               required:
               - driver
               type: object
+            custom_middleware_bundle:
+              type: string
             definition:
               properties:
                 key:
@@ -1677,6 +1679,7 @@ spec:
               - not_versioned
               type: object
           required:
+          - custom_middleware_bundle
           - name
           - protocol
           - proxy

--- a/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
+++ b/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
@@ -1679,7 +1679,6 @@ spec:
               - not_versioned
               type: object
           required:
-          - custom_middleware_bundle
           - name
           - protocol
           - proxy

--- a/helm/crds/crds.yaml
+++ b/helm/crds/crds.yaml
@@ -345,6 +345,8 @@ spec:
               required:
               - driver
               type: object
+            custom_middleware_bundle:
+              type: string
             definition:
               properties:
                 key:
@@ -1523,6 +1525,7 @@ spec:
               - not_versioned
               type: object
           required:
+          - custom_middleware_bundle
           - name
           - protocol
           - proxy

--- a/helm/crds/crds.yaml
+++ b/helm/crds/crds.yaml
@@ -1525,7 +1525,6 @@ spec:
               - not_versioned
               type: object
           required:
-          - custom_middleware_bundle
           - name
           - protocol
           - proxy


### PR DESCRIPTION
Other plugin related fields are enabled/present so there is no need for
this not to be present as well.

Closes #306