### PR TITLE
chore: preload deployment images for developing with shitty internet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,11 +169,11 @@ scrap: generate manifests helm cross-build-image
 
 .PHONY: setup-pro
 setup-pro:
-	go run hack/bootstrap/create/main.go --debug  --mode pro
+	go run hack/bootstrap/create/main.go --debug  --mode pro -cluster=${CLUSTER_NAME}
 
 .PHONY: setup-ce
 setup-ce:
-	go run hack/bootstrap/create/main.go --debug
+	go run hack/bootstrap/create/main.go --debug -cluster=${CLUSTER_NAME}
 
 
 .PHONY: boot-pro

--- a/ci/helm/tyk-headless/values.yaml
+++ b/ci/helm/tyk-headless/values.yaml
@@ -25,7 +25,7 @@ gateway:
   image:
     repository: tykio/tyk-gateway
     tag: v3.1.2
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   service:
     type: ClusterIP
     port: 8080

--- a/ci/helm/tyk-pro/values.yaml
+++ b/ci/helm/tyk-pro/values.yaml
@@ -80,7 +80,7 @@ dash:
   image:
     repository: tykio/tyk-dashboard
     tag: v3.1.2
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   service:
     type: ClusterIP
     port: 3000
@@ -146,11 +146,12 @@ gateway:
       value: "tcp://grpc-plugin.tykpro-control-plane.svc.cluster.local:9999"
 
 pump:
+  enabled: false
   replicaCount: 1
   image:
     repository: tykio/tyk-pump-docker-pub
     tag: v1.2.0
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   annotations: {}
   resources: {}
   nodeSelector: {}

--- a/ci/tyk-pro/mongo/mongo.yaml
+++ b/ci/tyk-pro/mongo/mongo.yaml
@@ -27,6 +27,7 @@ spec:
       containers:
         - image: mongo:latest
           name: mongo
+          imagePullPolicy: IfNotPresent
           ports:
             - name: mongo
               containerPort: 27017


### PR DESCRIPTION
I have terrible internet speeds (mobile) and it has been taking forever deploying local  development environment with kind.

This PR preloads all images deployed in the local cluster into kind node. This way k8s doesn't pull the image from the internet.

The images are still pulled on the local machine only once.

This also upgrades cert-manager used to `v1.3.1`