### PR TITLE
add annotation for api protocol

### DIFF
--- a/api/model/api.go
+++ b/api/model/api.go
@@ -48,6 +48,10 @@ type HttpMethod string
 // +kubebuilder:validation:Enum=proxyOnly;executionEngine
 type GraphQLExecutionMode string
 
+// APIProtocol is the network transport protocol supported by the gateway
+// +kubebuilder:validation:Enum=h2c;tcp;tls;http;https;
+type APIProtocol string
+
 type NotificationsManager struct {
 	SharedSecret      string `json:"shared_secret"`
 	OAuthKeyChangeURL string `json:"oauth_on_keychange_url"`
@@ -470,7 +474,6 @@ type OpenIDOptions struct {
 }
 
 // APIDefinition represents the configuration for a single proxied API and it's versions.
-
 type APIDefinitionSpec struct {
 
 	// For server use only, do not use
@@ -496,8 +499,7 @@ type APIDefinitionSpec struct {
 	// +optional
 	ListenPort int `json:"listen_port"`
 
-	// +kubebuilder:validation:Enum=http;https;tcp;tls
-	Protocol string `json:"protocol"`
+	Protocol APIProtocol `json:"protocol"`
 
 	EnableProxyProtocol bool `json:"enable_proxy_protocol,omitempty"`
 

--- a/api/v1alpha1/apidefinition_webhook.go
+++ b/api/v1alpha1/apidefinition_webhook.go
@@ -103,17 +103,7 @@ func path(n ...string) *field.Path {
 
 func (in *ApiDefinition) validate() error {
 	var all field.ErrorList
-	var _ APIDefinitionSpec
-
 	spec := in.Spec
-	// protocol
-	switch spec.Protocol {
-	case "", "h2c", "tcp", "tls", "http", "https":
-	default:
-		all = append(all,
-			field.NotSupported(path("protocol"), spec.Protocol, []string{"", "h2c", "tcp", "tls", "http", "https"}),
-		)
-	}
 
 	// auth
 	if spec.UseKeylessAccess {

--- a/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
+++ b/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
@@ -53,7 +53,6 @@ spec:
               API and it's versions.
             properties:
               CORS:
-                description: CORS cors settings
                 properties:
                   allow_credentials:
                     description: AllowCredentials if true will allow cookies
@@ -431,8 +430,6 @@ spec:
               enable_proxy_protocol:
                 type: boolean
               graphql:
-                description: GraphQLConfig is the root config object for a GraphQL
-                  API.
                 properties:
                   enabled:
                     description: Enabled indicates if GraphQL proxy should be enabled.
@@ -669,11 +666,14 @@ spec:
                 description: OrgID is overwritten - no point setting this
                 type: string
               protocol:
+                description: APIProtocol is the network transport protocol supported
+                  by the gateway
                 enum:
-                - http
-                - https
+                - h2c
                 - tcp
                 - tls
+                - http
+                - https
                 type: string
               proxy:
                 description: Proxy
@@ -757,8 +757,6 @@ spec:
                       outbound request would be http://httpbin.org/get
                     type: boolean
                   target_internal:
-                    description: TargetInternal defines options that constructs a
-                      url that refers to an api that is loaded into the gateway.
                     properties:
                       path:
                         description: "Path path on target , this does not include

--- a/helm/crds/crds.yaml
+++ b/helm/crds/crds.yaml
@@ -46,7 +46,6 @@ spec:
             description: APIDefinition represents the configuration for a single proxied API and it's versions.
             properties:
               CORS:
-                description: CORS cors settings
                 properties:
                   allow_credentials:
                     description: AllowCredentials if true will allow cookies
@@ -386,7 +385,6 @@ spec:
               enable_proxy_protocol:
                 type: boolean
               graphql:
-                description: GraphQLConfig is the root config object for a GraphQL API.
                 properties:
                   enabled:
                     description: Enabled indicates if GraphQL proxy should be enabled.
@@ -583,11 +581,13 @@ spec:
                 description: OrgID is overwritten - no point setting this
                 type: string
               protocol:
+                description: APIProtocol is the network transport protocol supported by the gateway
                 enum:
-                - http
-                - https
+                - h2c
                 - tcp
                 - tls
+                - http
+                - https
                 type: string
               proxy:
                 description: Proxy
@@ -647,7 +647,6 @@ spec:
                     description: StripListenPath removes the inbound listen path in the outgoing request. e.g. http://acme.com/httpbin/get where `httpbin` is the listen path. The `httpbin` listen path which is used to identify the API loaded in Tyk is removed, and the outbound request would be http://httpbin.org/get
                     type: boolean
                   target_internal:
-                    description: TargetInternal defines options that constructs a url that refers to an api that is loaded into the gateway.
                     properties:
                       path:
                         description: "Path path on target , this does not include query parameters. \texample /myendpoint"


### PR DESCRIPTION
This removes manual validation of api protocol by generating openapi spec for
it.