### PR TITLE
run automated tests against k8s 1.21 and upgrade older versions

### DIFF
--- a/.github/workflows/pro.yaml
+++ b/.github/workflows/pro.yaml
@@ -11,9 +11,10 @@ jobs:
           [
             "kindest/node:v1.16.15",
             "kindest/node:v1.17.17",
-            "kindest/node:v1.18.15",
-            "kindest/node:v1.19.7",
-            "kindest/node:v1.20.2",
+            "kindest/node:v1.18.19",
+            "kindest/node:v1.19.11",
+            "kindest/node:v1.20.7",
+            "kindest/node:v1.21.1"
           ]
     steps:
       - name: checkout tyk-operator


### PR DESCRIPTION
```
    1.21: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
    1.20: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
    1.19: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
    1.18: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
    1.17: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
    1.16: kindest/node:v1.16.15@sha256:83067ed51bf2a3395b24687094e283a7c7c865ccc12a8b1d7aa673ba0c5e8861
```