### PR TITLE
Remove default context requirement

### DIFF
--- a/controllers/ingress_controller.go
+++ b/controllers/ingress_controller.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/TykTechnologies/tyk-operator/api/model"
 	"github.com/TykTechnologies/tyk-operator/api/v1alpha1"
-	"github.com/TykTechnologies/tyk-operator/pkg/client/universal"
 	"github.com/TykTechnologies/tyk-operator/pkg/environmet"
 	"github.com/TykTechnologies/tyk-operator/pkg/keys"
 	"github.com/go-logr/logr"
@@ -46,11 +45,10 @@ import (
 // IngressReconciler watches and reconciles Ingress objects
 type IngressReconciler struct {
 	client.Client
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	UniversalClient universal.Client
-	Env             environmet.Env
-	Recorder        record.EventRecorder
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Env      environmet.Env
+	Recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/portalapicatalogue_controller.go
+++ b/controllers/portalapicatalogue_controller.go
@@ -31,7 +31,7 @@ import (
 	"github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 	tykv1alpha1 "github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 	uc "github.com/TykTechnologies/tyk-operator/pkg/client"
-	"github.com/TykTechnologies/tyk-operator/pkg/client/universal"
+	"github.com/TykTechnologies/tyk-operator/pkg/client/klient"
 	"github.com/TykTechnologies/tyk-operator/pkg/environmet"
 	"github.com/TykTechnologies/tyk-operator/pkg/keys"
 )
@@ -39,10 +39,9 @@ import (
 // PortalAPICatalogueReconciler reconciles a PortalAPICatalogue object
 type PortalAPICatalogueReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Scheme    *runtime.Scheme
-	Universal universal.Client
-	Env       environmet.Env
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Env    environmet.Env
 }
 
 //+kubebuilder:rbac:groups=tyk.tyk.io,resources=portalapicatalogues,verbs=get;list;watch;create;update;patch;delete
@@ -155,7 +154,7 @@ func (r *PortalAPICatalogueReconciler) sync(
 			Documentation:     a.APIDocumentation.Documentation,
 			APIID:             a.PolicyID,
 		}
-		res, err := r.Universal.Portal().Documentation().Upload(ctx, d)
+		res, err := klient.Universal.Portal().Documentation().Upload(ctx, d)
 		if err != nil {
 			return err
 		}
@@ -169,10 +168,10 @@ func (r *PortalAPICatalogueReconciler) init(
 	desired *tykv1alpha1.PortalAPICatalogue,
 	env environmet.Env,
 ) (id string, err error) {
-	cat, err := r.Universal.Portal().Catalogue().Get(ctx)
+	cat, err := klient.Universal.Portal().Catalogue().Get(ctx)
 	if err != nil {
 		if uc.IsNotFound(err) {
-			result, err := r.Universal.Portal().Catalogue().Create(ctx, &model.APICatalogue{
+			result, err := klient.Universal.Portal().Catalogue().Create(ctx, &model.APICatalogue{
 				OrgId: env.Org,
 			})
 			if err != nil {
@@ -201,7 +200,7 @@ func (r *PortalAPICatalogueReconciler) create(
 		return err
 	}
 	m.Id = catalogueID
-	_, err = r.Universal.Portal().Catalogue().Update(ctx, m)
+	_, err = klient.Universal.Portal().Catalogue().Update(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -220,7 +219,7 @@ func (r *PortalAPICatalogueReconciler) update(
 		return err
 	}
 	m.Id = desired.Status.ID
-	_, err = r.Universal.Portal().Catalogue().Update(ctx, m)
+	_, err = klient.Universal.Portal().Catalogue().Update(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -235,7 +234,7 @@ func (r *PortalAPICatalogueReconciler) consolidate(
 	env environmet.Env,
 	log logr.Logger,
 ) error {
-	all, err := r.Universal.Portal().Catalogue().Get(ctx)
+	all, err := klient.Universal.Portal().Catalogue().Get(ctx)
 	if err != nil {
 		return err
 	}
@@ -249,7 +248,7 @@ func (r *PortalAPICatalogueReconciler) consolidate(
 		if v.Documentation != "" {
 			_, ok := m[v.Documentation]
 			if !ok {
-				_, err := r.Universal.Portal().Documentation().Delete(ctx, v.Documentation)
+				_, err := klient.Universal.Portal().Documentation().Delete(ctx, v.Documentation)
 				if err != nil {
 					if !uc.IsNotFound(err) {
 						return err
@@ -268,7 +267,7 @@ func (r *PortalAPICatalogueReconciler) delete(
 	log logr.Logger,
 ) error {
 	log.Info("Deleting PortalAPICatalogue")
-	all, err := r.Universal.Portal().Catalogue().Get(ctx)
+	all, err := klient.Universal.Portal().Catalogue().Get(ctx)
 	if err != nil {
 		return err
 	}
@@ -276,7 +275,7 @@ func (r *PortalAPICatalogueReconciler) delete(
 	for _, v := range all.APIS {
 		if v.Documentation != "" {
 			log.Info("Deleting", "Target", v.Documentation)
-			_, err := r.Universal.Portal().Documentation().Delete(ctx, v.Documentation)
+			_, err := klient.Universal.Portal().Documentation().Delete(ctx, v.Documentation)
 			if err != nil {
 				if !uc.IsNotFound(err) {
 					return err
@@ -286,7 +285,7 @@ func (r *PortalAPICatalogueReconciler) delete(
 	}
 	// There is no actual DELETE api for catalogue. What we can do is we can update
 	// the catalogue with zero APIDescription and remove the finalizer.
-	_, err = r.Universal.Portal().Catalogue().Update(ctx, &model.APICatalogue{
+	_, err = klient.Universal.Portal().Catalogue().Update(ctx, &model.APICatalogue{
 		Id:    desired.Status.ID,
 		OrgId: env.Org,
 	})

--- a/controllers/portalconfig_controller.go
+++ b/controllers/portalconfig_controller.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 	tykv1alpha1 "github.com/TykTechnologies/tyk-operator/api/v1alpha1"
-	"github.com/TykTechnologies/tyk-operator/pkg/client/universal"
+	"github.com/TykTechnologies/tyk-operator/pkg/client/klient"
 	"github.com/TykTechnologies/tyk-operator/pkg/environmet"
 	"github.com/TykTechnologies/tyk-operator/pkg/keys"
 )
@@ -35,10 +35,9 @@ import (
 // PortalConfigReconciler reconciles a PortalConfig object
 type PortalConfigReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Scheme    *runtime.Scheme
-	Universal universal.Client
-	Env       environmet.Env
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Env    environmet.Env
 }
 
 //+kubebuilder:rbac:groups=tyk.tyk.io,resources=portalconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -97,9 +96,9 @@ func (r *PortalConfigReconciler) create(
 	//
 	// We check if we have this object in dashboard already and we just update the
 	// object to match the resource state
-	conf, err := r.Universal.Portal().Configuration().Get(ctx)
+	conf, err := klient.Universal.Portal().Configuration().Get(ctx)
 	if err != nil {
-		res, err := r.Universal.Portal().Configuration().Create(ctx, &desired.Spec.PortalModelPortalConfig)
+		res, err := klient.Universal.Portal().Configuration().Create(ctx, &desired.Spec.PortalModelPortalConfig)
 		if err != nil {
 			return err
 		}
@@ -110,7 +109,7 @@ func (r *PortalConfigReconciler) create(
 	d := desired.Spec.PortalModelPortalConfig
 	d.Id = conf.Id
 	d.OrgID = conf.OrgID
-	_, err = r.Universal.Portal().Configuration().Update(ctx, &d)
+	_, err = klient.Universal.Portal().Configuration().Update(ctx, &d)
 	if err != nil {
 		log.Error(err, "Failed updating portal configuration")
 		return err
@@ -129,7 +128,7 @@ func (r *PortalConfigReconciler) update(
 	d := desired.Spec.PortalModelPortalConfig
 	d.Id = desired.Status.ID
 	d.OrgID = env.Org
-	_, err := r.Universal.Portal().Configuration().Update(ctx, &d)
+	_, err := klient.Universal.Portal().Configuration().Update(ctx, &d)
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(false)))
 	var env environmet.Env
+	env.Parse()
 	if env.Namespace == "" {
 		setupLog.Info("unable to get WatchNamespace, " +
 			"the manager will watch and manage resources in all Namespaces")

--- a/main.go
+++ b/main.go
@@ -33,9 +33,6 @@ import (
 
 	tykv1alpha1 "github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 	"github.com/TykTechnologies/tyk-operator/controllers"
-	"github.com/TykTechnologies/tyk-operator/pkg/client/dashboard"
-	"github.com/TykTechnologies/tyk-operator/pkg/client/gateway"
-	"github.com/TykTechnologies/tyk-operator/pkg/client/universal"
 	"github.com/TykTechnologies/tyk-operator/pkg/environmet"
 	// +kubebuilder:scaffold:imports
 )
@@ -99,21 +96,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize universal client
-	var universalClient universal.Client
-	universalClient = gateway.Client{}
-	if env.Mode == "pro" {
-		universalClient = dashboard.Client{}
-	}
-
 	a := ctrl.Log.WithName("controllers").WithName("ApiDefinition")
 	if err = (&controllers.ApiDefinitionReconciler{
-		Client:          mgr.GetClient(),
-		Log:             a,
-		Scheme:          mgr.GetScheme(),
-		UniversalClient: universalClient,
-		Env:             env,
-		Recorder:        mgr.GetEventRecorderFor("apidefinition-controller"),
+		Client:   mgr.GetClient(),
+		Log:      a,
+		Scheme:   mgr.GetScheme(),
+		Env:      env,
+		Recorder: mgr.GetEventRecorderFor("apidefinition-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ApiDefinition")
 		os.Exit(1)
@@ -121,12 +110,11 @@ func main() {
 
 	il := ctrl.Log.WithName("controllers").WithName("Ingress")
 	if err = (&controllers.IngressReconciler{
-		Client:          mgr.GetClient(),
-		Log:             il,
-		Scheme:          mgr.GetScheme(),
-		UniversalClient: universalClient,
-		Env:             env,
-		Recorder:        mgr.GetEventRecorderFor("ingress-controller"),
+		Client:   mgr.GetClient(),
+		Log:      il,
+		Scheme:   mgr.GetScheme(),
+		Env:      env,
+		Recorder: mgr.GetEventRecorderFor("ingress-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Ingress")
 		os.Exit(1)
@@ -134,23 +122,21 @@ func main() {
 
 	sl := ctrl.Log.WithName("controllers").WithName("SecretCert")
 	if err = (&controllers.SecretCertReconciler{
-		Client:          mgr.GetClient(),
-		Log:             sl,
-		Scheme:          mgr.GetScheme(),
-		UniversalClient: universalClient,
-		Env:             env,
+		Client: mgr.GetClient(),
+		Log:    sl,
+		Scheme: mgr.GetScheme(),
+		Env:    env,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SecretCert")
 		os.Exit(1)
 	}
 	sp := ctrl.Log.WithName("controllers").WithName("SecurityPolicy")
 	if err = (&controllers.SecurityPolicyReconciler{
-		Client:          mgr.GetClient(),
-		Log:             sp,
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("securitypolicy-controller"),
-		UniversalClient: universalClient,
-		Env:             env,
+		Client:   mgr.GetClient(),
+		Log:      sp,
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("securitypolicy-controller"),
+		Env:      env,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SecurityPolicy")
 		os.Exit(1)
@@ -178,21 +164,19 @@ func main() {
 	}
 
 	if err = (&controllers.PortalAPICatalogueReconciler{
-		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("PortalAPICatalogue"),
-		Scheme:    mgr.GetScheme(),
-		Universal: universalClient,
-		Env:       env,
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("PortalAPICatalogue"),
+		Scheme: mgr.GetScheme(),
+		Env:    env,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PortalAPICatalogue")
 		os.Exit(1)
 	}
 	if err = (&controllers.PortalConfigReconciler{
-		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("PortalConfig"),
-		Scheme:    mgr.GetScheme(),
-		Universal: universalClient,
-		Env:       env,
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("PortalConfig"),
+		Scheme: mgr.GetScheme(),
+		Env:    env,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PortalConfig")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -63,10 +63,6 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(false)))
 	var env environmet.Env
-	if err := env.Parse(); err != nil {
-		setupLog.Error(err, "unable to configure Tyk Client")
-		os.Exit(1)
-	}
 	if env.Namespace == "" {
 		setupLog.Info("unable to get WatchNamespace, " +
 			"the manager will watch and manage resources in all Namespaces")

--- a/pkg/client/klient/universal_client.go
+++ b/pkg/client/klient/universal_client.go
@@ -13,7 +13,7 @@ import (
 
 var _ universal.Client = (*Client)(nil)
 
-var UniversalClient = Client{}
+var Universal = Client{}
 
 func get(ctx context.Context) universal.Client {
 	r := client.GetContext(ctx)
@@ -23,6 +23,8 @@ func get(ctx context.Context) universal.Client {
 	return gateway.Client{}
 }
 
+// Implements universal.Client but picks the correct client dynamically based on
+// context.Context
 type Client struct{}
 
 func (Client) HotReload(ctx context.Context) error {

--- a/pkg/client/klient/universal_client.go
+++ b/pkg/client/klient/universal_client.go
@@ -1,0 +1,150 @@
+package klient
+
+import (
+	"context"
+
+	"github.com/TykTechnologies/tyk-operator/api/model"
+	"github.com/TykTechnologies/tyk-operator/api/v1alpha1"
+	"github.com/TykTechnologies/tyk-operator/pkg/client"
+	"github.com/TykTechnologies/tyk-operator/pkg/client/dashboard"
+	"github.com/TykTechnologies/tyk-operator/pkg/client/gateway"
+	"github.com/TykTechnologies/tyk-operator/pkg/client/universal"
+)
+
+var _ universal.Client = (*Client)(nil)
+
+var UniversalClient = Client{}
+
+func get(ctx context.Context) universal.Client {
+	r := client.GetContext(ctx)
+	if r.Env.Mode == "pro" {
+		return dashboard.Client{}
+	}
+	return gateway.Client{}
+}
+
+type Client struct{}
+
+func (Client) HotReload(ctx context.Context) error {
+	return get(ctx).HotReload(ctx)
+}
+
+func (Client) Api() universal.Api {
+	return Api{}
+}
+func (Client) Portal() universal.Portal {
+	return Portal{}
+}
+
+func (Client) Certificate() universal.Certificate {
+	return Certificate{}
+}
+
+type Api struct{}
+
+func (Api) Create(ctx context.Context, def *model.APIDefinitionSpec) (*model.Result, error) {
+	return get(ctx).Api().Create(ctx, def)
+}
+func (Api) Get(ctx context.Context, id string) (*model.APIDefinitionSpec, error) {
+	return get(ctx).Api().Get(ctx, id)
+}
+
+func (Api) Update(ctx context.Context, spec *model.APIDefinitionSpec) (*model.Result, error) {
+	return get(ctx).Api().Update(ctx, spec)
+}
+func (Api) Delete(ctx context.Context, id string) (*model.Result, error) {
+	return get(ctx).Api().Delete(ctx, id)
+}
+func (Api) List(ctx context.Context, options ...model.ListAPIOptions) (*model.APIDefinitionSpecList, error) {
+	return get(ctx).Api().List(ctx, options...)
+}
+
+type Portal struct{}
+
+func (Portal) Policy() universal.Policy {
+	return Policy{}
+}
+func (Portal) Documentation() universal.Documentation {
+	return Documentation{}
+}
+func (Portal) Catalogue() universal.Catalogue {
+	return Catalogue{}
+}
+func (Portal) Configuration() universal.Configuration {
+	return Configuration{}
+}
+
+type Policy struct{}
+
+func (Policy) All(ctx context.Context) ([]v1alpha1.SecurityPolicySpec, error) {
+	return get(ctx).Portal().Policy().All(ctx)
+}
+func (Policy) Get(ctx context.Context, id string) (*v1alpha1.SecurityPolicySpec, error) {
+	return get(ctx).Portal().Policy().Get(ctx, id)
+}
+func (Policy) Create(ctx context.Context, def *v1alpha1.SecurityPolicySpec) error {
+	return get(ctx).Portal().Policy().Create(ctx, def)
+}
+func (Policy) Update(ctx context.Context, def *v1alpha1.SecurityPolicySpec) error {
+	return get(ctx).Portal().Policy().Update(ctx, def)
+}
+
+func (Policy) Delete(ctx context.Context, id string) error {
+	return get(ctx).Portal().Policy().Delete(ctx, id)
+}
+
+type Documentation struct{}
+
+func (Documentation) Upload(ctx context.Context, o *model.APIDocumentation) (*model.Result, error) {
+	return get(ctx).Portal().Documentation().Upload(ctx, o)
+}
+
+func (Documentation) Delete(ctx context.Context, id string) (*model.Result, error) {
+	return get(ctx).Portal().Documentation().Delete(ctx, id)
+}
+
+type Catalogue struct{}
+
+func (Catalogue) Get(ctx context.Context) (*model.APICatalogue, error) {
+	return get(ctx).Portal().Catalogue().Get(ctx)
+}
+
+func (Catalogue) Create(ctx context.Context, o *model.APICatalogue) (*model.Result, error) {
+	return get(ctx).Portal().Catalogue().Create(ctx, o)
+}
+
+func (Catalogue) Update(ctx context.Context, o *model.APICatalogue) (*model.Result, error) {
+	return get(ctx).Portal().Catalogue().Update(ctx, o)
+}
+
+type Configuration struct{}
+
+func (Configuration) Get(ctx context.Context) (*model.PortalModelPortalConfig, error) {
+	return get(ctx).Portal().Configuration().Get(ctx)
+}
+func (Configuration) Create(
+	ctx context.Context, o *model.PortalModelPortalConfig,
+) (*model.Result, error) {
+	return get(ctx).Portal().Configuration().Create(ctx, o)
+}
+func (Configuration) Update(
+	ctx context.Context, o *model.PortalModelPortalConfig,
+) (*model.Result, error) {
+	return get(ctx).Portal().Configuration().Update(ctx, o)
+}
+
+type Certificate struct{}
+
+func (Certificate) All(ctx context.Context) ([]string, error) {
+	return get(ctx).Certificate().All(ctx)
+}
+func (Certificate) Upload(ctx context.Context, key []byte, crt []byte) (id string, err error) {
+	return get(ctx).Certificate().Upload(ctx, key, crt)
+}
+func (Certificate) Delete(ctx context.Context, id string) error {
+	return get(ctx).Certificate().Delete(ctx, id)
+}
+
+func (Certificate) Exists(ctx context.Context, id string) bool {
+	return get(ctx).Certificate().Exists(ctx, id)
+}

--- a/pkg/environmet/env.go
+++ b/pkg/environmet/env.go
@@ -1,7 +1,6 @@
 package environmet
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -45,7 +44,7 @@ func (e Env) Merge(n Env) Env {
 }
 
 // Parse loads env vars into e and validates them, returning an error if validation fails.
-func (e *Env) Parse() error {
+func (e *Env) Parse() {
 	e.Namespace = strings.TrimSpace(os.Getenv(v1alpha1.WatchNamespace))
 	e.Mode = v1alpha1.OperatorContextMode(os.Getenv(v1alpha1.TykMode))
 	e.URL = strings.TrimSpace(os.Getenv(v1alpha1.TykURL))
@@ -57,29 +56,5 @@ func (e *Env) Parse() error {
 	e.IngressClass = os.Getenv(v1alpha1.IngressClass)
 	if e.Ingress.HTTPSPort == 0 {
 		e.Ingress.HTTPSPort = 8443
-	}
-	// verify
-	sample := []struct {
-		env, value string
-	}{
-		{v1alpha1.TykMode, string(e.Mode)},
-		{v1alpha1.TykURL, e.URL},
-		{v1alpha1.TykAuth, e.Auth},
-		{v1alpha1.TykORG, e.Org},
-	}
-	var ls []string
-	for _, v := range sample {
-		if v.value == "" {
-			ls = append(ls, v.env)
-		}
-	}
-	if len(ls) > 0 {
-		return fmt.Errorf("environment vars %v are missing", ls)
-	}
-	switch e.Mode {
-	case "oss", "ce", "pro":
-		return nil
-	default:
-		return fmt.Errorf("unknown TYK_MODE value %q", e.Mode)
 	}
 }


### PR DESCRIPTION
Right now you must provide default environment for the operator to boot. 

This PR removes this requirement, you can start the operator without any environment. And use `OperatorContext` with the crd.