### PR TITLE
mapping correct env var for organization

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -173,7 +173,7 @@ func GetContext(
 			})
 		}
 		if e.Org == "" {
-			value(v1alpha1.TykAuth, func(s string) (err error) {
+			value(v1alpha1.TykORG, func(s string) (err error) {
 				e.Org = s
 				return
 			})

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: tyk-operator
 description: A Helm chart to install the tyk-operator
 type: application
-version: 0.7.1 # version of the chart
+version: 0.7.2 # version of the chart


### PR DESCRIPTION
fixes #344  
This defect surfaces in the scenario where the organization id is provided to the environment via a secret & operator context.

The SecurityPolicy reconciler takes the organization id from the environment when it interracts with Policy resources.

```
kubectl create secret -n default generic myconf \
  --from-literal "TYK_AUTH=${TYK_AUTH}" \
  --from-literal "TYK_ORG=${TYK_ORG}" \
  --from-literal "TYK_MODE=pro" \
  --from-literal "TYK_URL=${TYK_URL}" \
  --from-literal "TYK_TLS_INSECURE_SKIP_VERIFY=true"
```

```
cat <<EOF | kubectl apply -f -
apiVersion: tyk.tyk.io/v1alpha1
kind: OperatorContext
metadata:
  name: mycontext
spec:
  secretRef:
    namespace: default
    name: myconf
EOF
```

```
cat <<EOF | kubectl apply -f -
apiVersion: tyk.tyk.io/v1alpha1
kind: ApiDefinition
metadata:
  name: httpbin-with-mycontext
spec:
  contextRef:
    name: mycontext
    namespace: default
  name: httpbin-with-mycontext
  use_keyless: true
  protocol: http
  active: true
  proxy:
    target_url: http://httpbin.org
    listen_path: /httpbin-with-mycontext
    strip_listen_path: true
  version_data:
    default_version: Default
    not_versioned: true
    versions:
      Default:
        name: Default
EOF
```

```
cat <<EOF | kubectl apply -f -
apiVersion: tyk.tyk.io/v1alpha1
kind: SecurityPolicy
metadata:
  name: httpbin-with-mycontext
spec:
  contextRef:
    name: mycontext
    namespace: default
  name: Org2 Security Policy
  state: active
  active: true
  access_rights_array:
    - name: httpbin-with-mycontext
      namespace: default
      versions:
        - Default
EOF
```