### PR TITLE
Reduce docker context by adding .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**
+!/api/**
+!/controllers/**
+!/pkg/**
+!go.mod
+!go.sum
+!main.go
+!manager.linux


### PR DESCRIPTION
This adds .dockerignore to only send files that are required to build the
docker image
