### PR TITLE
remove gh-pages based helm repo

### DIFF
--- a/.github/workflows/release_tag.yaml
+++ b/.github/workflows/release_tag.yaml
@@ -32,12 +32,3 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Package helm and update gh-pages with helm repo"
-        run: |
-          make update-helm-repo
-      - name: "commit and publish helm repo"
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "gh-pages"
-          force: true

--- a/Makefile
+++ b/Makefile
@@ -190,15 +190,3 @@ bdd:
 
 .PHONY: test-all
 test-all: test bdd
-
-TPM_CHARTS_PACKAGE=tmp/charts
-.PHONY: package-helm
-package-helm:
-	mkdir -p ${TPM_CHARTS_PACKAGE}
-	helm package ./helm -d ${TPM_CHARTS_PACKAGE}
-	helm repo index --merge ${TPM_CHARTS_PACKAGE}/index.yaml --url  https://tyktechnologies.github.io/tyk-operator ${TPM_CHARTS_PACKAGE}
-
-update-helm-repo: package-helm
-	git checkout gh-pages
-	cp -r ${TPM_CHARTS_PACKAGE}/ .
-


### PR DESCRIPTION
From v0.8.0 we will be using official tyk helm repository for publishing and
installing helm charts

