### PR TITLE
[TT-4489] Fix validation webhook error for empty target urls

### DIFF
--- a/api/v1alpha1/apidefinition_webhook.go
+++ b/api/v1alpha1/apidefinition_webhook.go
@@ -205,12 +205,14 @@ func (in *ApiDefinition) validateTarget() field.ErrorList {
 	// TargetURL is only allowed to be an empty string when we have GraphQL
 	// API, or we are targeting internal API by its name and namespace.
 	if in.Spec.Proxy.TargetURL == "" {
-		if in.Spec.GraphQL != nil && !in.Spec.GraphQL.Enabled {
-			all = append(all,
-				field.Required(path("proxy", "target_url"),
-					"can't be empty",
-				),
-			)
+		if in.Spec.GraphQL != nil {
+			if !in.Spec.GraphQL.Enabled {
+				all = append(all,
+					field.Required(path("proxy", "target_url"),
+						"can't be empty",
+					),
+				)
+			}
 		} else if in.Spec.Proxy.TargetInternal == nil {
 			all = append(all,
 				field.Required(path("proxy", "target_url"),

--- a/api/v1alpha1/apidefinition_webhook_test.go
+++ b/api/v1alpha1/apidefinition_webhook_test.go
@@ -143,6 +143,18 @@ func TestApiDefinition_validateTarget(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name: "valid ApiDefinition for UDG",
+			apiDef: ApiDefinition{
+				Spec: APIDefinitionSpec{
+					APIDefinitionSpec: model.APIDefinitionSpec{
+						Proxy:   model.Proxy{TargetURL: ""},
+						GraphQL: &model.GraphQLConfig{Enabled: true},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
 			name: "valid ApiDefinition, targeting internal API",
 			apiDef: ApiDefinition{
 				Spec: APIDefinitionSpec{
@@ -176,7 +188,7 @@ func TestApiDefinition_validateTarget(t *testing.T) {
 			apiDef: ApiDefinition{
 				Spec: APIDefinitionSpec{
 					APIDefinitionSpec: model.APIDefinitionSpec{
-						GraphQL: &model.GraphQLConfig{Enabled: true},
+						GraphQL: &model.GraphQLConfig{Enabled: false},
 					},
 				},
 			},


### PR DESCRIPTION
## Description

This PR updates a control statement in the `validateTarget` function. Previously, we were checking the GraphQL spec (2 fields related to GraphQL) in one line. Although the provided YAML files are GraphQL, if they are active (not enabled), then we are directly checking are we targeting an internal API by its name and namespace or not. 


## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `gofmt -s -w .`
  - [x] `go vet ./...`
  - [x] `golangci-lint run`
