### PR TITLE
[TT-4925] Fixed wrongly storing mutated CRDs in kubernetes instead of the initi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/TykTechnologies/tyk-operator/tree/HEAD)
 
-- Added a fix for a bug in which ApiDefinition CRDs were wrongly mutated ([])
+- Added a fix for a bug in which ApiDefinition CRDs were wrongly mutated 
 
 [Full Changelog](https://github.com/TykTechnologies/tyk-operator/compare/v0.8.1...HEAD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/TykTechnologies/tyk-operator/tree/HEAD)
 
+- Added a fix for a bug in which ApiDefinition CRDs were wrongly mutated ([])
+
 [Full Changelog](https://github.com/TykTechnologies/tyk-operator/compare/v0.8.1...HEAD)
 
 **Added:**

--- a/controllers/apidefinition_controller.go
+++ b/controllers/apidefinition_controller.go
@@ -116,9 +116,9 @@ func (r *ApiDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// we support only one certificate secret name for mvp
 		if len(desired.Spec.CertificateSecretNames) != 0 {
 			certName := desired.Spec.CertificateSecretNames[0]
-			tykCertID, err2, done := r.checkSecretAndUpload(ctx, certName, namespacedName, log, &env)
-			if done {
-				return err2
+			tykCertID, err, shouldRequeue := r.checkSecretAndUpload(ctx, certName, namespacedName, log, &env)
+			if shouldRequeue {
+				return err
 			}
 
 			upstreamRequestStruct.Spec.Certificates = []string{tykCertID}

--- a/controllers/apidefinition_controller.go
+++ b/controllers/apidefinition_controller.go
@@ -116,8 +116,8 @@ func (r *ApiDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		// we support only one certificate secret name for mvp
 		if len(desired.Spec.CertificateSecretNames) != 0 {
 			certName := desired.Spec.CertificateSecretNames[0]
-			tykCertID, err, shouldRequeue := r.checkSecretAndUpload(ctx, certName, namespacedName, log, &env)
-			if shouldRequeue {
+			tykCertID, err := r.checkSecretAndUpload(ctx, certName, namespacedName, log, &env)
+			if err != nil {
 				return err
 			}
 
@@ -162,28 +162,29 @@ func (r *ApiDefinitionReconciler) checkSecretAndUpload(
 	namespacedName types.NamespacedName,
 	log logr.Logger,
 	env *environmet.Env,
-) (string, error, bool) {
+) (string, error) {
 	secret := v1.Secret{}
 
 	err := r.Get(ctx, types.NamespacedName{Name: certName, Namespace: namespacedName.Namespace}, &secret)
 	if err != nil {
 		log.Error(err, "requeueing because secret not found")
-
-		return "", err, true
+		return "", err
 	}
 
 	pemCrtBytes, ok := secret.Data["tls.crt"]
 	if !ok {
+		err = fmt.Errorf("%s", "requeueing because cert not found in secret")
 		log.Error(err, "requeueing because cert not found in secret")
 
-		return "", err, true
+		return "", err
 	}
 
 	pemKeyBytes, ok := secret.Data["tls.key"]
 	if !ok {
+		err = fmt.Errorf("%s", "requeueing because key not found in secret")
 		log.Error(err, "requeueing because key not found in secret")
 
-		return "", err, true
+		return "", err
 	}
 
 	tykCertID := env.Org + cert.CalculateFingerPrint(pemCrtBytes)
@@ -193,11 +194,11 @@ func (r *ApiDefinitionReconciler) checkSecretAndUpload(
 		// upload the certificate
 		tykCertID, err = klient.Universal.Certificate().Upload(ctx, pemKeyBytes, pemCrtBytes)
 		if err != nil {
-			return "", err, true
+			return "", err
 		}
 	}
 
-	return tykCertID, nil, false
+	return tykCertID, nil
 }
 
 func (r *ApiDefinitionReconciler) create(


### PR DESCRIPTION
Fixed wrongly storing mutated CRDs in kubernetes instead of the initial ones by using a deepcopy that is mutated and then sent to the gateway.

Due to using a single ApiDefinition struct for storing both the “input” and “output” CRD values, at some point if we want to work with values that are not going to be passed to the gateway/dashboard (as they would fail the api structure validator) we used to mutate the ApiDefinitions obtained from kubernetes directly. This behaviour led to the kubernetes API being unable to recognize whether a CRD was created or updated (as the stored CRD would be different from the one that was applied initially).

<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

A solution identified together with Ahmet Soormally relies on deep-copying the initial ApiDefinition spec into an additional variable and mutating that and sending it to the gateway.

## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This behaviour led to the kubernetes API being unable to recognize whether a CRD was created or updated (as the stored CRD would be different from the one that was applied initially).

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] Make sure you are updating [CHANGELOG.md](../CHANGELOG.md) based on your changes.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `gofmt -s -w .`
  - [ ] `go vet ./...`
  - [ ] `golangci-lint run`
