### PR TITLE
[TT-3687] Changed default Analytics behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased](https://github.com/TykTechnologies/tyk-operator/tree/HEAD)
 [Full Changelog](https://github.com/TykTechnologies/tyk-operator/compare/v0.8.2...HEAD)
 
+**Breaking Changes:**
+- `do_not_track` field's default value is changed from `true` to `false`, to make default behaviour inline with Tyk Dashboard/Gateway.
+Therefore, Analytics for API will be enabled by default from this version. A user have to explicitly disable it by setting `do_not_track` field value to `true`.
+
 **Added:**
 - Added an [example YAML manifest](./config/samples/httpbin_endpoint_tracking.yaml) for Endpoint Tracking.
 - Added Support of Auth Headers while creating GraphQL ProxyOnly API

--- a/api/model/api.go
+++ b/api/model/api.go
@@ -540,7 +540,7 @@ type APIDefinitionSpec struct {
 	// Domain represents a custom host header that the gateway will listen on for this API
 	Domain string `json:"domain,omitempty"`
 
-	// DoNotTrack disables endpoint tracking for this API. Default is true, you need to explicitly set it to false
+	// DoNotTrack disables endpoint tracking for this API
 	DoNotTrack *bool `json:"do_not_track,omitempty"`
 
 	// UseKeylessAccess will switch off all key checking. Some analytics will still be recorded, but rate-limiting,

--- a/api/v1alpha1/apidefinition_webhook.go
+++ b/api/v1alpha1/apidefinition_webhook.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -49,11 +48,6 @@ var _ webhook.Defaulter = &ApiDefinition{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (in *ApiDefinition) Default() {
 	apidefinitionlog.Info("default", "name", in.Name)
-
-	// We disable tracking by default
-	if in.Spec.DoNotTrack == nil {
-		in.Spec.DoNotTrack = pointer.BoolPtr(true)
-	}
 
 	if len(in.Spec.VersionData.Versions) == 0 {
 		in.Spec.VersionData = model.VersionData{

--- a/api/v1alpha1/apidefinition_webhook_test.go
+++ b/api/v1alpha1/apidefinition_webhook_test.go
@@ -9,7 +9,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
 )
 
 func TestApiDefinition_Default(t *testing.T) {
@@ -39,50 +38,6 @@ func TestApiDefinition_Default(t *testing.T) {
 
 	if authConf.AuthHeaderName != "Authorization" {
 		t.Fatal("expected the authConf.AuthHeaderName to be Authorization, Got", authConf.AuthHeaderName)
-	}
-}
-
-func TestApiDefinition_Default_DoNotTrack(t *testing.T) {
-	in := ApiDefinition{
-		Spec: APIDefinitionSpec{
-			APIDefinitionSpec: model.APIDefinitionSpec{
-				UseStandardAuth: true,
-				DoNotTrack:      pointer.BoolPtr(true),
-			},
-		},
-	}
-	in.Default()
-
-	if *in.Spec.DoNotTrack != true {
-		t.Fatalf("expected DoNotTrack to be true as explicitly set, got %v", *in.Spec.DoNotTrack)
-	}
-
-	in = ApiDefinition{
-		Spec: APIDefinitionSpec{
-			APIDefinitionSpec: model.APIDefinitionSpec{
-				UseStandardAuth: true,
-				DoNotTrack:      nil,
-			},
-		},
-	}
-	in.Default()
-
-	if *in.Spec.DoNotTrack != true {
-		t.Fatalf("expected DoNotTrack to be true by default, got %v", *in.Spec.DoNotTrack)
-	}
-
-	in = ApiDefinition{
-		Spec: APIDefinitionSpec{
-			APIDefinitionSpec: model.APIDefinitionSpec{
-				UseStandardAuth: true,
-				DoNotTrack:      pointer.BoolPtr(false),
-			},
-		},
-	}
-	in.Default()
-
-	if *in.Spec.DoNotTrack != false {
-		t.Fatalf("expected DoNotTrack to be false as explicitly set, got %v", *in.Spec.DoNotTrack)
 	}
 }
 

--- a/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
+++ b/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
@@ -420,8 +420,7 @@ spec:
                 - strip_path
                 type: object
               do_not_track:
-                description: DoNotTrack disables endpoint tracking for this API. Default
-                  is true, you need to explicitly set it to false
+                description: DoNotTrack disables endpoint tracking for this API
                 type: boolean
               domain:
                 description: Domain represents a custom host header that the gateway

--- a/helm/crds/crds.yaml
+++ b/helm/crds/crds.yaml
@@ -377,7 +377,7 @@ spec:
                 - strip_path
                 type: object
               do_not_track:
-                description: DoNotTrack disables endpoint tracking for this API. Default is true, you need to explicitly set it to false
+                description: DoNotTrack disables endpoint tracking for this API
                 type: boolean
               domain:
                 description: Domain represents a custom host header that the gateway will listen on for this API


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
`do_not_track` field of API Definition will not be set to `true` by default. To disable analytics, user has to explicitly set it to true.

## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
Closes #324 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Ty Dashboard/Gateway enables analytics by default whereas Operator was turning it off.
This difference in behavior was causing confusion.

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested manually

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [x] Make sure you are updating [CHANGELOG.md](../CHANGELOG.md) based on your changes.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `gofmt -s -w .`
  - [x] `go vet ./...`
  - [x] `golangci-lint run`
