### PR TITLE
[TT-7327] Fix deleting non-existent ApiDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/TykTechnologies/tyk-operator/tree/HEAD)
 
+**Fixed**:
+- Fixed the error that happens while deleting non-existent Tyk APIs from k8s.
+
 ## [v0.13.0](https://github.com/TykTechnologies/tyk-operator/tree/HEAD)
 [Full Changelog](https://github.com/TykTechnologies/tyk-operator/compare/v0.12.0...HEAD)
 

--- a/controllers/apidefinition_controller.go
+++ b/controllers/apidefinition_controller.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
-
 	"github.com/TykTechnologies/tyk-operator/api/model"
 	tykv1alpha1 "github.com/TykTechnologies/tyk-operator/api/v1alpha1"
 	"github.com/TykTechnologies/tyk-operator/pkg/cert"
@@ -35,7 +33,7 @@ import (
 	"github.com/TykTechnologies/tyk-operator/pkg/client/klient"
 	"github.com/TykTechnologies/tyk-operator/pkg/environmet"
 	"github.com/TykTechnologies/tyk-operator/pkg/keys"
-
+	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -184,10 +182,10 @@ func (r *ApiDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		//  If this is not set, means it is a new object, set it first
 		if desired.Status.ApiID == "" {
-			return r.create(ctx, upstreamRequestStruct, log)
+			return r.create(ctx, upstreamRequestStruct)
 		}
 
-		return r.update(ctx, upstreamRequestStruct, log)
+		return r.update(ctx, upstreamRequestStruct)
 	})
 
 	if err == nil {
@@ -382,16 +380,18 @@ func (r *ApiDefinitionReconciler) checkSecretAndUpload(
 	return uploadCert(ctx, env.Org, pemKeyBytes, pemCrtBytes)
 }
 
-func (r *ApiDefinitionReconciler) create(
-	ctx context.Context,
-	desired *tykv1alpha1.ApiDefinition,
-	log logr.Logger,
-) error {
-	log.Info("Creating a new ApiDefinition")
+func (r *ApiDefinitionReconciler) create(ctx context.Context, desired *tykv1alpha1.ApiDefinition) error {
+	r.Log.Info("Creating a new ApiDefinition",
+		"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
+	)
 
 	_, err := klient.Universal.Api().Create(ctx, &desired.Spec.APIDefinitionSpec)
 	if err != nil {
-		log.Error(err, "Failed to create ApiDefinition on Tyk")
+		r.Log.Error(
+			err,
+			"Failed to create ApiDefinition on Tyk",
+			"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
+		)
 		return err
 	}
 
@@ -405,9 +405,10 @@ func (r *ApiDefinitionReconciler) create(
 		},
 	)
 	if err != nil {
-		log.Error(err, "Failed to update Status ID",
-			"ApiDefinition",
-			client.ObjectKeyFromObject(desired),
+		r.Log.Error(
+			err,
+			"Failed to update Status ID",
+			"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
 		)
 
 		return err
@@ -415,9 +416,10 @@ func (r *ApiDefinitionReconciler) create(
 
 	err = klient.Universal.HotReload(ctx)
 	if err != nil {
-		log.Error(err,
+		r.Log.Error(
+			err,
 			"Failed to hot-reload Tyk after creating the ApiDefinition",
-			"ApiDefinition", client.ObjectKeyFromObject(desired),
+			"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
 		)
 
 		return err
@@ -426,24 +428,26 @@ func (r *ApiDefinitionReconciler) create(
 	return nil
 }
 
-func (r *ApiDefinitionReconciler) update(
-	ctx context.Context,
-	desired *tykv1alpha1.ApiDefinition,
-	log logr.Logger,
-) error {
-	log.Info("Updating ApiDefinition")
+func (r *ApiDefinitionReconciler) update(ctx context.Context, desired *tykv1alpha1.ApiDefinition) error {
+	r.Log.Info("Updating ApiDefinition",
+		"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
+	)
 
 	_, err := klient.Universal.Api().Update(ctx, &desired.Spec.APIDefinitionSpec)
 	if err != nil {
-		log.Error(err, "Failed to update api definition")
+		r.Log.Error(
+			err, "Failed to update ApiDefinition on Tyk",
+			"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
+		)
 		return err
 	}
 
 	err = klient.Universal.HotReload(ctx)
 	if err != nil {
-		log.Error(err,
+		r.Log.Error(
+			err,
 			"Failed to hot-reload Tyk after updating the ApiDefinition",
-			"ApiDefinition", client.ObjectKeyFromObject(desired),
+			"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
 		)
 
 		return err
@@ -532,7 +536,9 @@ func (r *ApiDefinitionReconciler) syncTemplate(ctx context.Context, ns string, a
 }
 
 func (r *ApiDefinitionReconciler) delete(ctx context.Context, desired *tykv1alpha1.ApiDefinition) (time.Duration, error) {
-	r.Log.Info("ApiDefinition being deleted", "ApiDefinition", client.ObjectKeyFromObject(desired))
+	r.Log.Info("ApiDefinition being deleted",
+		"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
+	)
 
 	// If our finalizer is present, need to delete from Tyk still
 	if util.ContainsFinalizer(desired, keys.ApiDefFinalizerName) {
@@ -560,7 +566,7 @@ func (r *ApiDefinitionReconciler) delete(ctx context.Context, desired *tykv1alph
 
 		err := r.breakSubgraphLink(ctx, desired, true)
 		if err != nil {
-			return 0, err
+			return queueAfter, err
 		}
 
 		r.Log.Info("Deleting an ApiDefinition from Tyk", "ApiDefinition ID", desired.Status.ApiID)
@@ -578,20 +584,25 @@ func (r *ApiDefinitionReconciler) delete(ctx context.Context, desired *tykv1alph
 			// Therefore, check if ApiDefinition exists on Tyk before returning with error. If ApiDefinition
 			// exists, which means Get call returns successful response, Operator should reconcile to complete
 			// deletion of the ApiDefinition.
-			_, err = klient.Universal.Api().Get(ctx, desired.Status.ApiID)
-			if err == nil {
+			_, errTyk := klient.Universal.Api().Get(ctx, desired.Status.ApiID)
+			if errTyk == nil {
 				r.Log.Error(
 					err,
 					"Failed to delete ApiDefinition from Tyk", "api_id", desired.Status.ApiID,
 				)
-				return 0, err
+				return queueAfter, err
 			}
 		}
 
 		err = klient.Universal.HotReload(ctx)
 		if err != nil {
-			r.Log.Error(err, "unable to hot reload", "api_id", desired.Status.ApiID)
-			return 0, err
+			r.Log.Error(
+				err,
+				"Failed to hot-reload Tyk after deleting the ApiDefinition",
+				"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
+			)
+
+			return queueAfter, err
 		}
 
 		util.RemoveFinalizer(desired, keys.ApiDefFinalizerName)
@@ -599,7 +610,7 @@ func (r *ApiDefinitionReconciler) delete(ctx context.Context, desired *tykv1alph
 
 	r.Log.Info(
 		"Deleted ApiDefinition successfully",
-		"ApiDefinition", client.ObjectKeyFromObject(desired),
+		"ApiDefinition", client.ObjectKeyFromObject(desired).String(),
 	)
 
 	return 0, nil
@@ -684,7 +695,7 @@ func (r *ApiDefinitionReconciler) ensureTargets(
 func (r *ApiDefinitionReconciler) updateLoopingTargets(ctx context.Context,
 	a *tykv1alpha1.ApiDefinition, links []model.Target,
 ) error {
-	r.Log.Info("updating looping targets")
+	r.Log.Info("Updating looping targets")
 
 	if len(links) == 0 {
 		return nil
@@ -812,7 +823,7 @@ func (r *ApiDefinitionReconciler) breakSubgraphLink(
 		if err != nil {
 			r.Log.Error(err,
 				"failed to update ApiDefinition status after removing Subgraph link",
-				"ApiDefinition CR", client.ObjectKeyFromObject(desired),
+				"ApiDefinition CR", client.ObjectKeyFromObject(desired).String(),
 			)
 
 			return err

--- a/integration/apidefinition_test.go
+++ b/integration/apidefinition_test.go
@@ -1389,7 +1389,7 @@ func TestDeletingNonexistentAPI(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("Delete ApiDefinition from Tyk",
+		Assess("Delete nonexistent ApiDefinition from k8s successfully",
 			func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 				// To begin with, delete the ApiDefinition from Tyk, which is the wrong thing to do because it'll
 				// cause a drift between k8s and Tyk. Now, deleting ApiDefinition CR from k8s,

--- a/integration/apidefinition_test.go
+++ b/integration/apidefinition_test.go
@@ -32,6 +32,24 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
+func deleteApiDefinitionFromTyk(ctx context.Context, id string) error {
+	err := wait.For(func() (done bool, err error) {
+		_, err = klient.Universal.Api().Delete(ctx, id)
+		if err != nil {
+			return false, err
+		}
+
+		err = klient.Universal.HotReload(ctx)
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}, wait.WithTimeout(defaultWaitTimeout), wait.WithInterval(defaultWaitInterval))
+
+	return err
+}
+
 func TestApiDefinitionJSONSchemaValidation(t *testing.T) {
 	var (
 		apiDefWithJSONValidationName = "apidef-json-validation"
@@ -1343,4 +1361,64 @@ func TestApiDefinitionSubGraphExecutionMode(t *testing.T) {
 	})
 
 	testenv.Test(t, gqlSubGraph)
+}
+
+func TestDeletingNonexistentAPI(t *testing.T) {
+	var (
+		opNs   = "tyk-operator-system"
+		eval   = is.New(t)
+		tykCtx context.Context
+		tykEnv environmet.Env
+	)
+
+	testDeletingNonexistentAPIs := features.New("Deleting Nonexistent APIs from k8s").
+		Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			opConfSecret := v1.Secret{}
+
+			err := c.Client().Resources(opNs).Get(ctx, "tyk-operator-conf", opNs, &opConfSecret)
+			eval.NoErr(err)
+
+			// Obtain Environment configuration to be able to connect Tyk.
+			tykEnv, err = generateEnvConfig(&opConfSecret)
+			eval.NoErr(err)
+
+			tykCtx = tykClient.SetContext(context.Background(), tykClient.Context{
+				Env: tykEnv,
+				Log: log.NullLogger{},
+			})
+
+			return ctx
+		}).
+		Assess("Delete ApiDefinition from Tyk",
+			func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				// To begin with, delete the ApiDefinition from Tyk, which is the wrong thing to do because it'll
+				// cause a drift between k8s and Tyk. Now, deleting ApiDefinition CR from k8s,
+				// `kubectl delete tykapis <resource_name>`, must be handled gracefully.
+				testNs, ok := ctx.Value(ctxNSKey).(string)
+				eval.True(ok)
+
+				// First, create the ApiDefinition
+				apiDefCR, err := createTestAPIDef(ctx, c, testNs, func(apiDef *v1alpha1.ApiDefinition) {})
+				eval.NoErr(err)
+
+				err = waitForTykResourceCreation(c, apiDefCR)
+				eval.NoErr(err)
+
+				err = deleteApiDefinitionFromTyk(tykCtx, apiDefCR.Status.ApiID)
+				eval.NoErr(err)
+
+				err = c.Client().Resources(testNs).Delete(ctx, apiDefCR)
+				eval.NoErr(err)
+
+				err = wait.For(
+					conditions.New(c.Client().Resources()).ResourceDeleted(apiDefCR),
+					wait.WithTimeout(defaultWaitTimeout),
+					wait.WithInterval(defaultWaitInterval),
+				)
+				eval.NoErr(err)
+
+				return ctx
+			}).Feature()
+
+	testenv.Test(t, testDeletingNonexistentAPIs)
 }


### PR DESCRIPTION
## Description

This PR adds an additional check in `delete` method of ApiDefinition to control unexpected responses while deleting non-existent APIs in CE. Although the new version (v4.3) of the Gateway does not have such an issue, deleting non-existent APIs in older versions of GW returns 500 which is not detected as `NotFound` error in Operator. This unexpected response code causes unexpected reconciliation on Operator.

To solve this issue, we check the existence of ApiDefinition after deleting it if any error occurred. 

## Related Issue
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-7327
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
1- Create an ApiDefinition in K8s
```
kubectl apply -f ./config/samples/httpbin.yaml
```
2- Get its ID and delete it from Tyk first.
```
curl -X DELETE -H "x-tyk-authorization: foo" http://localhost:8080/tyk/apis/${API_ID} -i && curl -H "x-tyk-authorization: foo" -s http://localhost:8080/tyk/reload/group
```

3- Deleting k8s resource should not create any issue
```
kubectl delete tykapis httpbin
```

Changes must be consistent across Tyk v3.2 and v4.3

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] Make sure you are updating [CHANGELOG.md](https://github.com/TykTechnologies/tyk-operator/blob/master/CHANGELOG.md) based on your changes.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] If you've changed API models, please update CRDs.
  - [ ] `make manifests`
  - [ ] `make helm`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `gofmt -s -w .`
  - [x] `go vet ./...`
  - [x] `golangci-lint run`
