### PR TITLE
Added possibility to set base identity provider for multiple chained …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased](https://github.com/TykTechnologies/tyk-operator/tree/HEAD)
+
+**Added**
+- Added possiblility to set base identity provider
+
 ## [v0.14.1](https://github.com/TykTechnologies/tyk-operator/tree/HEAD)
 [Full Changelog](https://github.com/TykTechnologies/tyk-operator/compare/v0.14.0...HEAD)
 

--- a/api/model/api.go
+++ b/api/model/api.go
@@ -680,7 +680,9 @@ type APIDefinitionSpec struct {
 	// HmacAllowedClockSkew       json.Number           `json:"hmac_allowed_clock_skew"` // TODO: convert to float64
 	// HmacAllowedAlgorithms      []string              `json:"hmac_allowed_algorithms"`
 	// RequestSigning             RequestSigningMeta    `json:"request_signing"`
-	// BaseIdentityProvidedBy     AuthTypeEnum          `json:"base_identity_provided_by"`
+
+	// BaseIdentityProvidedBy sets Base Identity Provider for situation when multiple authentication mechanisms are used
+	BaseIdentityProvidedBy AuthTypeEnum `json:"base_identity_provided_by,omitempty"`
 
 	VersionDefinition VersionDefinition `json:"definition,omitempty"`
 

--- a/api/model/api.go
+++ b/api/model/api.go
@@ -682,6 +682,7 @@ type APIDefinitionSpec struct {
 	// RequestSigning             RequestSigningMeta    `json:"request_signing"`
 
 	// BaseIdentityProvidedBy sets Base Identity Provider for situation when multiple authentication mechanisms are used
+	// +kubebuilder:validation:Enum=auth_token;hmac_key;basic_auth_user;jwt_claim;oidc_user;oauth_key
 	BaseIdentityProvidedBy AuthTypeEnum `json:"base_identity_provided_by,omitempty"`
 
 	VersionDefinition VersionDefinition `json:"definition,omitempty"`

--- a/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
+++ b/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
@@ -218,6 +218,13 @@ spec:
               base_identity_provided_by:
                 description: BaseIdentityProvidedBy sets Base Identity Provider for
                   situation when multiple authentication mechanisms are used
+                enum:
+                - auth_token
+                - hmac_key
+                - basic_auth_user
+                - jwt_claim
+                - oidc_user
+                - oauth_key
                 type: string
               blacklisted_ips:
                 description: BlacklistedIPs is a list of IP address that will be blacklisted.This

--- a/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
+++ b/config/crd/bases/tyk.tyk.io_apidefinitions.yaml
@@ -215,6 +215,10 @@ spec:
                   - auth_header_name
                   type: object
                 type: object
+              base_identity_provided_by:
+                description: BaseIdentityProvidedBy sets Base Identity Provider for
+                  situation when multiple authentication mechanisms are used
+                type: string
               blacklisted_ips:
                 description: BlacklistedIPs is a list of IP address that will be blacklisted.This
                   means if origin IP matches any IP in this list a 403 http status

--- a/config/samples/multiple-auth/httpbin_basic_authentication_and_mTLS.yaml
+++ b/config/samples/multiple-auth/httpbin_basic_authentication_and_mTLS.yaml
@@ -1,0 +1,24 @@
+# Here we are creating an API definition with basic authentication and mTLS with basic authentication as base identy for httpbin 
+
+apiVersion: tyk.tyk.io/v1alpha1
+kind: ApiDefinition
+metadata:
+  name: httpbin-multiple-authentications
+spec:
+  name: Httpbin Multiple Authentications
+  protocol: http
+  active: true
+  base_identity_provided_by: BasicAuthUser
+  proxy:
+    target_url: http://httpbin.org
+    listen_path: /httpbin
+    strip_listen_path: true
+  version_data:
+    default_version: Default
+    not_versioned: true
+    versions:
+      Default:
+        name: Default
+  use_basic_auth: true
+  use_mutual_tls_auth: true
+  

--- a/config/samples/multiple-auth/httpbin_basic_authentication_and_mTLS.yaml
+++ b/config/samples/multiple-auth/httpbin_basic_authentication_and_mTLS.yaml
@@ -8,7 +8,7 @@ spec:
   name: Httpbin Multiple Authentications
   protocol: http
   active: true
-  base_identity_provided_by: BasicAuthUser
+  base_identity_provided_by: basic_auth_user
   proxy:
     target_url: http://httpbin.org
     listen_path: /httpbin

--- a/docs/api_definitions.md
+++ b/docs/api_definitions.md
@@ -51,6 +51,7 @@ To check the supported features of the API Definitions CRD version you're curren
 | mTLS                          | ✅      | v0.11              | Only static client mTLS is supported | [Sample](./../config/samples/mtls/client/) |
 | HMAC                          | ❌        | -              | Not implemented | |
 | Basic Authentication          | ✅        | v0.12          | Only enabling with default metadata values is supported  | [Sample](./../config/samples/basic-auth/httpbin_basic_authentication.yaml) |
+| Multiple (Chained) Auth       | ✅        | v0.14          | - | [Sample](./../config/samples/multiple-auth/httpbin_basic_authentication_and_mTLS.yaml) |
 | Plugin Auth - Go              | ✅        | v0.11          | - | [Sample](./api_definitions/custom_plugin_goauth.yaml) |
 | Plugin Auth - gRPC            | ✅        | v0.1           | - | [Sample](./../bdd/features/api_http_grpc_plugin.feature) |
 | IP Whitelisting               | ✅        | v0.5           | - | [Sample](./api_definitions/ip.md#whitelisting) |

--- a/helm/crds/crds.yaml
+++ b/helm/crds/crds.yaml
@@ -191,6 +191,9 @@ spec:
                   - auth_header_name
                   type: object
                 type: object
+              base_identity_provided_by:
+                description: BaseIdentityProvidedBy sets Base Identity Provider for situation when multiple authentication mechanisms are used
+                type: string
               blacklisted_ips:
                 description: BlacklistedIPs is a list of IP address that will be blacklisted.This means if origin IP matches any IP in this list a 403 http status code will be returned. The IP address can be IPv4 or IPv6. IP in CIDR notation is also supported.
                 items:

--- a/helm/crds/crds.yaml
+++ b/helm/crds/crds.yaml
@@ -193,6 +193,13 @@ spec:
                 type: object
               base_identity_provided_by:
                 description: BaseIdentityProvidedBy sets Base Identity Provider for situation when multiple authentication mechanisms are used
+                enum:
+                - auth_token
+                - hmac_key
+                - basic_auth_user
+                - jwt_claim
+                - oidc_user
+                - oauth_key
                 type: string
               blacklisted_ips:
                 description: BlacklistedIPs is a list of IP address that will be blacklisted.This means if origin IP matches any IP in this list a 403 http status code will be returned. The IP address can be IPv4 or IPv6. IP in CIDR notation is also supported.

--- a/integration/apidefinition_test.go
+++ b/integration/apidefinition_test.go
@@ -1010,10 +1010,97 @@ func TestApiDefinitionBasicAuth(t *testing.T) {
 
 					apiDef, err = klient.Universal.Api().Get(reqCtx, apiDefCRD.Status.ApiID)
 					if err != nil {
-						return false, errors.New("API is not created yet")
+						t.Logf("API %v is not created yet on Tyk", apiDefCRD.Status.ApiID)
+						return false, nil
 					}
 
 					eval.True(apiDef.UseBasicAuth)
+
+					return true, nil
+				}, wait.WithTimeout(defaultWaitTimeout), wait.WithInterval(defaultWaitInterval))
+				eval.NoErr(err)
+
+				eval.True(apiDef.UseBasicAuth)
+
+				return ctx
+			}).Feature()
+
+	testenv.Test(t, testBasicAuth)
+}
+
+func TestApiDefinitionBaseIdentityProviderWithMultipleAuthTypes(t *testing.T) {
+	var (
+		apiDefBasicAndMTLSAuth = "apidef-basic-and-mtls-authentication"
+		defaultVersion         = "Default"
+
+		eval   = is.New(t)
+		reqCtx context.Context
+		tykEnv environmet.Env
+	)
+
+	testBasicAuth := features.New("Base Identity Provider for Basic Auth and mTLS").
+		Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			opConfSecret := v1.Secret{}
+
+			err := c.Client().Resources(opNs).Get(ctx, operatorSecret, opNs, &opConfSecret)
+			eval.NoErr(err)
+
+			// Obtain Environment configuration to be able to connect Tyk.
+			tykEnv, err = generateEnvConfig(&opConfSecret)
+			eval.NoErr(err)
+
+			reqCtx = tykClient.SetContext(context.Background(), tykClient.Context{
+				Env: tykEnv,
+				Log: log.NullLogger{},
+			})
+
+			return ctx
+		}).
+		Setup(func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			testNS, ok := ctx.Value(ctxNSKey).(string)
+			eval.True(ok)
+
+			// Create ApiDefinition with Basic Authentication and mTLS enabled with BasicAuthUser as base identity provider
+			_, err := createTestAPIDef(ctx, envConf, testNS, func(apiDef *v1alpha1.ApiDefinition) {
+				apiDef.Name = apiDefBasicAndMTLSAuth
+				apiDef.Spec.UseBasicAuth = true
+				apiDef.Spec.UseMutualTLSAuth = true
+				apiDef.Spec.BaseIdentityProvidedBy = "BasicAuthUser"
+				apiDef.Spec.VersionData.DefaultVersion = defaultVersion
+				apiDef.Spec.VersionData.NotVersioned = true
+				apiDef.Spec.VersionData.Versions = map[string]model.VersionInfo{
+					defaultVersion: {Name: defaultVersion},
+				}
+			})
+			eval.NoErr(err) // failed to create apiDefinition
+
+			return ctx
+		}).
+		Assess("API must have base identity provider set",
+			func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				testNS, ok := ctx.Value(ctxNSKey).(string)
+				eval.True(ok)
+
+				var apiDef *model.APIDefinitionSpec
+
+				err := wait.For(func() (done bool, err error) {
+					// validate base identity provider and all authentication fields
+					var apiDefCRD v1alpha1.ApiDefinition
+
+					err = c.Client().Resources().Get(ctx, apiDefBasicAndMTLSAuth, testNS, &apiDefCRD)
+					if err != nil {
+						return false, err
+					}
+
+					apiDef, err = klient.Universal.Api().Get(reqCtx, apiDefCRD.Status.ApiID)
+					if err != nil {
+						t.Logf("API %v is not created yet on Tyk", apiDefCRD.Status.ApiID)
+						return false, nil
+					}
+
+					eval.True(apiDef.UseBasicAuth)
+					eval.True(apiDef.UseMutualTLSAuth)
+					eval.Equal(apiDef.BaseIdentityProvidedBy, model.AuthTypeEnum("BasicAuthUser"))
 
 					return true, nil
 				}, wait.WithTimeout(defaultWaitTimeout), wait.WithInterval(defaultWaitInterval))

--- a/integration/apidefinition_test.go
+++ b/integration/apidefinition_test.go
@@ -1065,7 +1065,7 @@ func TestApiDefinitionBaseIdentityProviderWithMultipleAuthTypes(t *testing.T) {
 				apiDef.Name = apiDefBasicAndMTLSAuth
 				apiDef.Spec.UseBasicAuth = true
 				apiDef.Spec.UseMutualTLSAuth = true
-				apiDef.Spec.BaseIdentityProvidedBy = "BasicAuthUser"
+				apiDef.Spec.BaseIdentityProvidedBy = "basic_auth_user"
 				apiDef.Spec.VersionData.DefaultVersion = defaultVersion
 				apiDef.Spec.VersionData.NotVersioned = true
 				apiDef.Spec.VersionData.Versions = map[string]model.VersionInfo{
@@ -1100,7 +1100,7 @@ func TestApiDefinitionBaseIdentityProviderWithMultipleAuthTypes(t *testing.T) {
 
 					eval.True(apiDef.UseBasicAuth)
 					eval.True(apiDef.UseMutualTLSAuth)
-					eval.Equal(apiDef.BaseIdentityProvidedBy, model.AuthTypeEnum("BasicAuthUser"))
+					eval.Equal(apiDef.BaseIdentityProvidedBy, model.AuthTypeEnum("basic_auth_user"))
 
 					return true, nil
 				}, wait.WithTimeout(defaultWaitTimeout), wait.WithInterval(defaultWaitInterval))


### PR DESCRIPTION
Adding the possibility to set base_identity_provider through tyk-operator. 

## Description
Currently you are able to set mutliple auth mechanism - however base_identity_provider remains empty which makes the dashboard confused about the true authentication type selected. That has implications for key creatation and update. 
Until this PR - if you : 
1. create an apidefinition with use_basic_auth and use_mutual_tls_auth enabled 
2. process that through tyk-operator 
3. create policy with previously created API 
4. create key in the dashboard
5. observe that the key only recognizes basic authentication and it is not enforcing mTLS certificate

## Related Issue
NA

## Motivation and Context
We are using multiple authentication on our project and we want our API to be fully compliant with standard to rule out unpredictable behavior

## Test Coverage For This Change
Added unit test TestApiDefinitionBaseIdentityProviderWithMultipleAuthTypes in apidefinition_test.go following a similar structure to the mtls configuration.
Added config/samples/multiple-auth/httpbin_basic_authentication_and_mTLS.yaml
Executed manual tests on kind cluster using ce mode

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [x] Make sure you are updating [CHANGELOG.md](https://github.com/TykTechnologies/tyk-operator/blob/master/CHANGELOG.md) based on your changes.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [x] I have updated the documentation accordingly.
- [x] If you've changed API models, please update CRDs.
  - [x] `make manifests`
  - [x] `make helm`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `gofmt -s -w .`
  - [x] `go vet ./...`
  - [x] `golangci-lint run`
